### PR TITLE
Make starpower be awarded on hitting last note of phrase

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -23,6 +23,11 @@ namespace YARG.PlayMode {
 		protected List<NoteInfo> Chart => Play.Instance.chart
 			.GetChartByName(player.chosenInstrument)[(int) player.chosenDifficulty];
 
+		protected int visualChartIndex = 0;
+		protected int realChartIndex = 0;
+		protected int eventChartIndex = 0;
+		protected int currentChartIndex = 0;
+
 		[SerializeField]
 		protected Camera trackCamera;
 
@@ -201,7 +206,7 @@ namespace YARG.PlayMode {
 
 		private void UpdateStarpower() {
 			// Update starpower region
-			if (StarpowerSection?.EndTime + Play.HIT_MARGIN < Play.Instance.SongTime) {
+			if (IsStarpowerHit()) {
 				StarpowerSection = null;
 				starpowerCharge += 0.25f;
 			}
@@ -253,6 +258,11 @@ namespace YARG.PlayMode {
 
 		protected float CalcLagCompensation(float currentTime, float noteTime) {
 			return (currentTime - noteTime) * (player.trackSpeed / Play.speed);
+		}
+
+		private bool IsStarpowerHit() {
+			if (Chart.Count > currentChartIndex) return Chart[currentChartIndex].time >= StarpowerSection?.EndTime;
+			else return false;
 		}
 	}
 }

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -29,10 +29,6 @@ namespace YARG.PlayMode {
 		[SerializeField]
 		private ParticleGroup kickNoteParticles;
 
-		private int visualChartIndex = 0;
-		private int realChartIndex = 0;
-		private int eventChartIndex = 0;
-
 		private Queue<List<NoteInfo>> expectedHits = new();
 
 		private int notesHit = 0;
@@ -175,6 +171,7 @@ namespace YARG.PlayMode {
 				// Call miss for each component
 				Combo = 0;
 				foreach (var hit in missedChord) {
+					currentChartIndex++;
 					notePool.MissNote(hit);
 					StopAudio = true;
 				}
@@ -237,6 +234,7 @@ namespace YARG.PlayMode {
 			}
 
 			// Hit note
+			currentChartIndex++;
 			notePool.HitNote(hit);
 			StopAudio = false;
 

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -23,10 +23,6 @@ namespace YARG.PlayMode {
 		[SerializeField]
 		private ParticleGroup openNoteParticles;
 
-		private int visualChartIndex = 0;
-		private int realChartIndex = 0;
-		private int eventChartIndex = 0;
-
 		private Queue<List<NoteInfo>> expectedHits = new();
 		private List<List<NoteInfo>> allowedOverstrums = new();
 		private List<NoteInfo> heldNotes = new();
@@ -158,6 +154,7 @@ namespace YARG.PlayMode {
 				// Call miss for each component
 				Combo = 0;
 				foreach (var hit in missedChord) {
+					currentChartIndex++;
 					notePool.MissNote(hit);
 					StopAudio = true;
 				}
@@ -213,6 +210,7 @@ namespace YARG.PlayMode {
 						while (expectedHits.Peek() != chord) {
 							var missedChord = expectedHits.Dequeue();
 							foreach (var hit in missedChord) {
+								currentChartIndex++;
 								notePool.MissNote(hit);
 							}
 						}
@@ -253,6 +251,7 @@ namespace YARG.PlayMode {
 
 			Combo++;
 			foreach (var hit in chord) {
+				currentChartIndex++;
 				// Hit notes
 				notePool.HitNote(hit);
 				StopAudio = false;

--- a/Assets/Script/PlayMode/RealGuitarTrack.cs
+++ b/Assets/Script/PlayMode/RealGuitarTrack.cs
@@ -28,10 +28,6 @@ namespace YARG.PlayMode {
 		[SerializeField]
 		private Pool genericPool;
 
-		private int visualChartIndex = 0;
-		private int realChartIndex = 0;
-		private int eventChartIndex = 0;
-
 		private Queue<NoteInfo> expectedHits = new();
 		private List<NoteInfo> heldNotes = new();
 
@@ -153,6 +149,7 @@ namespace YARG.PlayMode {
 				var missedNote = expectedHits.Dequeue();
 
 				// Call miss for each component
+				currentChartIndex++;
 				Combo = 0;
 				notePool.MissNote(missedNote);
 				StopAudio = true;
@@ -184,6 +181,7 @@ namespace YARG.PlayMode {
 			}
 
 			// If so, hit!
+			currentChartIndex++;
 			expectedHits.Dequeue();
 
 			Combo++;


### PR DESCRIPTION
Currently, starpower is awarded on the end of star power phrase; that is incorrect behavior, as it should be awarded on hitting the last note of the SP phrase.
TODO: test on Drums (as SP reading isn't implemented yet, verifying that currentChartIndex is being counted accurately, similarly to how it is counted on five-fret, should be enough)