### PR TITLE
Fix bot overstrumming after adding strum leniency

### DIFF
--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -454,7 +454,9 @@ namespace YARG.PlayMode {
 			}
 
 			strummed = true;
-			strumLeniency = Play.STRUM_LENIENCY;
+			if (!input.botMode) {
+				strumLeniency = Play.STRUM_LENIENCY;
+			}
 		}
 
 		private void SpawnNote(NoteInfo noteInfo, float time) {


### PR DESCRIPTION
As the bot is set to strum on every note, this causes overstrumming with chords as the event is fired for every note in the chord, this PR fixes that by only setting strum leniency in normal play