### PR TITLE
Add update check on startup

### DIFF
--- a/Assets/Scenes/MenuScene.unity
+++ b/Assets/Scenes/MenuScene.unity
@@ -5584,6 +5584,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 527108656}
   m_CullTransparentMesh: 1
+--- !u!1 &528723087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 528723088}
+  - component: {fileID: 528723090}
+  - component: {fileID: 528723089}
+  m_Layer: 5
+  m_Name: Version
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &528723088
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528723087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 852858603}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 135, y: 0}
+  m_SizeDelta: {x: 75, y: 19}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &528723089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528723087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: v12.34.56
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: f941d094fa226f74e9866f5e556ce769, type: 2}
+  m_sharedMaterial: {fileID: 3946058399964092608, guid: f941d094fa226f74e9866f5e556ce769,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &528723090
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528723087}
+  m_CullTransparentMesh: 1
 --- !u!1001 &554838494
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7274,6 +7410,199 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f87a30883027ef469e70d57fce0a257, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &719589147
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 719589148}
+  - component: {fileID: 719589151}
+  - component: {fileID: 719589150}
+  - component: {fileID: 719589149}
+  m_Layer: 5
+  m_Name: UpdateText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &719589148
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 719589147}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1099876206}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 112.5, y: 12.5}
+  m_SizeDelta: {x: 225, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &719589149
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 719589147}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 0.8908121, b: 0.2688679, a: 1}
+    m_PressedColor: {r: 0.8018868, g: 0.61138165, b: 0.17777678, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 719589150}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 874813134}
+        m_TargetAssemblyTypeName: YARG.UI.MainMenu, Assembly-CSharp
+        m_MethodName: OpenLatestRelease
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &719589150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 719589147}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'New version available: v23.45.67'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -35.321884, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &719589151
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 719589147}
+  m_CullTransparentMesh: 1
 --- !u!1 &740866311
 GameObject:
   m_ObjectHideFlags: 0
@@ -8381,13 +8710,14 @@ RectTransform:
   m_Children:
   - {fileID: 1899482973}
   - {fileID: 1342524125}
+  - {fileID: 528723088}
   m_Father: {fileID: 1126244164}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 25, y: -57}
-  m_SizeDelta: {x: 150, y: 32}
+  m_SizeDelta: {x: 210, y: 32}
   m_Pivot: {x: 0, y: 0}
 --- !u!1 &858583937
 GameObject:
@@ -8610,6 +8940,8 @@ MonoBehaviour:
   loadingScreen: {fileID: 784751310}
   loadingStatus: {fileID: 1090956613}
   progressBar: {fileID: 1649890904}
+  versionText: {fileID: 528723089}
+  updateObject: {fileID: 1099876205}
 --- !u!1 &882788346
 GameObject:
   m_ObjectHideFlags: 0
@@ -10507,6 +10839,43 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1099876205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1099876206}
+  m_Layer: 5
+  m_Name: Update
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1099876206
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1099876205}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 719589148}
+  m_Father: {fileID: 1126244164}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 92, y: 10}
+  m_SizeDelta: {x: 82, y: 24}
+  m_Pivot: {x: 1, y: 0.0000001620501}
 --- !u!1 &1126244163
 GameObject:
   m_ObjectHideFlags: 0
@@ -10538,6 +10907,7 @@ RectTransform:
   - {fileID: 852858603}
   - {fileID: 464394842}
   - {fileID: 331516586}
+  - {fileID: 1099876206}
   m_Father: {fileID: 874813133}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -12588,7 +12958,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 40, y: -32}
-  m_SizeDelta: {x: 110, y: 32}
+  m_SizeDelta: {x: 90, y: 32}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1342524126
 MonoBehaviour:

--- a/Assets/Scenes/PersistantScene.unity
+++ b/Assets/Scenes/PersistantScene.unity
@@ -249,6 +249,7 @@ GameObject:
   m_Component:
   - component: {fileID: 788257160}
   - component: {fileID: 788257161}
+  - component: {fileID: 788257162}
   m_Layer: 0
   m_Name: Game Manager
   m_TagString: Untagged
@@ -285,6 +286,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   vocalGroup: {fileID: -541741410412472071, guid: d5f8521c55f50a44eb1e292204769821,
     type: 2}
+--- !u!114 &788257162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788257159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5937911890937c4e97d340c6d6b2831, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &874125449
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -1,0 +1,11 @@
+namespace YARG {
+	public static class Constants {
+
+		public const int MAJOR_VERSION = 0;
+		public const int MINOR_VERSION = 8;
+		public const int PATCH_VERSION = 1;
+
+		public static readonly string VERSION_TAG = $"v{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}";
+
+	}	
+}

--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -3,7 +3,7 @@ namespace YARG {
 
 		public const int MAJOR_VERSION = 0;
 		public const int MINOR_VERSION = 8;
-		public const int PATCH_VERSION = 1;
+		public const int PATCH_VERSION = 2;
 
 		public static readonly string VERSION_TAG = $"v{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}";
 

--- a/Assets/Script/Constants.cs.meta
+++ b/Assets/Script/Constants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd014b86a5f29d04dbd32055121c987c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/GameManager.cs
+++ b/Assets/Script/GameManager.cs
@@ -30,6 +30,8 @@ namespace YARG {
 			private set;
 		}
 
+		public UpdateChecker updateChecker;
+		
 		[SerializeField]
 		private AudioMixerGroup vocalGroup;
 
@@ -37,6 +39,7 @@ namespace YARG {
 
 		private void Start() {
 			Instance = this;
+			updateChecker = GetComponent<UpdateChecker>();
 			PersistentDataPath = Application.persistentDataPath;
 			Settings.SettingsManager.Init();
 

--- a/Assets/Script/UI/MainMenu.cs
+++ b/Assets/Script/UI/MainMenu.cs
@@ -1,6 +1,6 @@
-using System.IO;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 using YARG.Data;
 using YARG.Input;
@@ -46,9 +46,23 @@ namespace YARG.UI {
 		[SerializeField]
 		private Image progressBar;
 
+		[SerializeField]
+		private TextMeshProUGUI versionText;
+
+		[SerializeField]
+		private GameObject updateObject;
+		
+		private TextMeshProUGUI updateText;
+
+		private bool isUpdateShown;
+		
 		private void Start() {
 			Instance = this;
 
+			versionText.text = Constants.VERSION_TAG;
+
+			updateText = updateObject.GetComponentInChildren<TextMeshProUGUI>();
+			
 			if (SongLibrary.SongsByHash == null) {
 				RefreshSongLibrary();
 			}
@@ -95,6 +109,14 @@ namespace YARG.UI {
 			// Update player navigation
 			foreach (var player in PlayerManager.players) {
 				player.inputStrategy.UpdateNavigationMode();
+			}
+
+			if (!isUpdateShown && GameManager.Instance.updateChecker.IsOutOfDate) {
+				isUpdateShown = true;
+				
+				string newVersion = GameManager.Instance.updateChecker.LatestVersion;
+				updateText.text = $"New version available: {newVersion}";
+				updateObject.gameObject.gameObject.SetActive(true);
 			}
 		}
 
@@ -209,6 +231,10 @@ namespace YARG.UI {
 			ScoreManager.FetchScores();
 
 			SongSelect.refreshFlag = true;
+		}
+
+		public void OpenLatestRelease() {
+			Application.OpenURL("https://github.com/EliteAsian123/YARG/releases/latest");
 		}
 
 		public void Quit() {

--- a/Assets/Script/UpdateChecker.cs
+++ b/Assets/Script/UpdateChecker.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+
+namespace YARG {
+	public class UpdateChecker : MonoBehaviour {
+    	
+    	private CancellationTokenSource updateTokenSource;
+    	
+    	public bool CheckedForUpdates { get; private set; }
+    	public bool IsOutOfDate { get; private set; }
+    	
+    	public string LatestVersion { get; private set; }
+    	
+        private void Start() {
+            CheckForUpdates();
+        }
+        
+        private async void CheckForUpdates() {
+    	    // #if UNITY_EDITOR
+    	    // return;
+    	    // #endif
+    	    updateTokenSource = new CancellationTokenSource();
+    	    
+    	    Debug.Log("Checking for updates");
+    	    CheckedForUpdates = true;
+    	    
+    	    try {
+    		    // Setup request
+    		    var request = (HttpWebRequest)WebRequest.Create("https://api.github.com/repos/EliteAsian123/YARG/releases/latest");
+    		    request.UserAgent = "YARG";
+    				
+    		    // Sets up a cancellation token to cancel the request if needed (such as menu being hidden)
+    		    await using (updateTokenSource.Token.Register(() => request.Abort(), useSynchronizationContext: false)) {
+    			    var response = await request.GetResponseAsync();
+    			    updateTokenSource.Token.ThrowIfCancellationRequested();
+    
+    			    if (response is null) {
+    				    throw new WebException("Failed to get response from Update check");
+    			    }
+    					
+    			    // Read response
+    			    string json = await new StreamReader(response.GetResponseStream()!).ReadToEndAsync();
+    
+    			    // Get version tag
+    			    var jsonObject = JsonConvert.DeserializeObject<JToken>(json);
+    			    var releaseTag = jsonObject["tag_name"]!.Value<string>();
+
+    			    LatestVersion = releaseTag;
+                    
+                    if (Constants.VERSION_TAG != LatestVersion) {
+	                    IsOutOfDate = true;
+                    }
+
+                    Debug.Log(LatestVersion != Constants.VERSION_TAG
+    				    ? $"Update available! New version: {releaseTag}"
+    				    : "Game is up to date.");
+    		    }
+    	    } catch(Exception e) {
+    		    Debug.Log("Update check cancelled");
+    		    Debug.LogError(e.Message);
+    		    Debug.LogError(e.StackTrace);
+    	    } finally {
+    		    updateTokenSource.Dispose();
+    		    updateTokenSource = null;
+    	    }
+        }
+    }
+}

--- a/Assets/Script/UpdateChecker.cs.meta
+++ b/Assets/Script/UpdateChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5937911890937c4e97d340c6d6b2831
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a check for new releases when the game launches. Version must be changed for new releases using the `MAJOR`, `MINOR` and `PATCH` integers in `Constants.cs`, and the release must be tagged in the repository matching the client version.

- Checks for updates using the GitHub releases API on startup
- Added current version next to logo on main menu
- Update notification appears on main menu when game is out of date