### PR TITLE
Fix lefty flip on 4 and 5 lane drums

### DIFF
--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -42,14 +42,6 @@ namespace YARG.PlayMode {
 
 			noKickMode = SettingsManager.GetSettingValue<bool>("noKicks");
 
-			// Lefty flip
-
-			if (player.leftyFlip) {
-				drums = drums.Reverse().ToArray();
-				// Make the drum colors follow RYBG even though the chart is flipped
-				Array.Reverse(drumColors, 0, 4);
-			}
-
 			// Inputs
 
 			input = player.inputStrategy;
@@ -64,6 +56,14 @@ namespace YARG.PlayMode {
 			// GH vs RB
 
 			kickIndex = fiveLaneMode ? 5 : 4;
+			
+			// Lefty flip
+
+			if (player.leftyFlip) {
+				drums = drums.Reverse().ToArray();
+				// Make the drum colors follow the original order even though the chart is flipped
+				Array.Reverse(drumColors, 0, kickIndex);
+			}
 
 			// Color drums
 			for (int i = 0; i < drums.Length; i++) {

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System;
 using UnityEngine;
 using YARG.Data;
 using YARG.Input;
@@ -45,6 +46,8 @@ namespace YARG.PlayMode {
 
 			if (player.leftyFlip) {
 				drums = drums.Reverse().ToArray();
+				// Make the drum colors follow RYBG even though the chart is flipped
+				Array.Reverse(drumColors, 0, 4);
 			}
 
 			// Inputs


### PR DESCRIPTION
All that was done was reversing the order of the drum colors back to the original, whilst the chart is still flipped, as expected.

Fixes #56 