### PR TITLE
Fix lefty flip drum inputs

### DIFF
--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -186,6 +186,28 @@ namespace YARG.PlayMode {
 		}
 
 		private void DrumHitAction(int drum, bool cymbal) {
+			// invert input in case lefty flip is on
+			if (player.leftyFlip){
+				switch (drum){
+					case 0:
+						drum = kickIndex == 4 ? 3 : 4;
+						break;
+					case 1:
+						drum = kickIndex == 4 ? 2 : 3;
+						break;
+					case 2:
+						drum = kickIndex == 4 ? 1 : 2;
+						break;
+					case 3:
+						drum = kickIndex == 4 ? 0 : 1;
+						break;
+					case 4:
+						if (kickIndex == 5){
+							drum = 0;
+						}
+						break;
+				}
+			}
 			if (drum != kickIndex) {
 				// Hit effect
 				drums[drum].Pulse();

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -186,8 +186,8 @@ namespace YARG.PlayMode {
 		}
 
 		private void DrumHitAction(int drum, bool cymbal) {
-			// invert input in case lefty flip is on
-			if (player.leftyFlip){
+			// invert input in case lefty flip is on, bots don't need it
+			if (player.leftyFlip && !input.botMode){
 				switch (drum){
 					case 0:
 						drum = kickIndex == 4 ? 3 : 4;


### PR DESCRIPTION
#96 did not fix the inputs, only the note colors, as DarkRTA mentioned.
I've now flipped the inputs when they're being processed as a hit, except when bot mode is on.
Fixes #56 for real this time.