### PR TITLE
Re-enable incremental garbage collection

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -830,7 +830,7 @@ PlayerSettings:
   selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
-  gcIncremental: 0
+  gcIncremental: 1
   assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}


### PR DESCRIPTION
Somehow incremental garbage collection (Unity's default GC setting) got turned off, which causes huge lag spikes in the editor. Incremental GC spreads garbage collection over multiple frames so it doesn't pause the application for as long. This should mitigate it and from a quick test it seems to. 

Probably best to find the root cause of the large allocations though, some quick profiling showed GameManager being the place where large GC Invokes are occurring but it could be more subtle. 