### PR TITLE
Fix starpower going over 1

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -208,6 +208,9 @@ namespace YARG.PlayMode {
 			if (IsStarpowerHit()) {
 				StarpowerSection = null;
 				starpowerCharge += 0.25f;
+				if (starpowerCharge > 1f) {
+					starpowerCharge = 1f;
+				}
 			}
 
 			// Update starpower active


### PR DESCRIPTION
Starpower should be capped out at a full bar (1.00), however there was no check to see if the charge exceeded 1 when adding 0.25 to it after hitting a phrase.