### PR TITLE
Support song speedups in new audio engine

### DIFF
--- a/Assets/Script/Audio/IAudioManager.cs
+++ b/Assets/Script/Audio/IAudioManager.cs
@@ -2,7 +2,8 @@ using System.Collections.Generic;
 
 namespace YARG {
 	public interface IAudioManager {
-		public bool UseStarpowerFx { get; set; }
+		public bool UseStarpowerFx  { get; set; }
+		public bool IsChipmunkSpeedup { get; set; }
 
 		public IList<string> SupportedFormats { get; }
 
@@ -22,7 +23,7 @@ namespace YARG {
 
 		public void LoadSfx();
 
-		public void LoadSong(IEnumerable<string> stems);
+		public void LoadSong(IEnumerable<string> stems, bool isSpeedUp);
 		public void UnloadSong();
 
 		public void Play();

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -268,7 +268,7 @@ namespace YARG.PlayMode {
 					GameManager.AudioManager.PlaySoundEffect(SfxSample.StarPowerRelease);
 					SetReverb(false);
 				} else {
-					starpowerCharge -= Time.deltaTime / 25f;
+					starpowerCharge -= Time.deltaTime / 25f * Play.speed;
 				}
 
 				// Start track animation

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -95,7 +96,7 @@ namespace YARG.PlayMode {
 			// Load audio
 			var stems = AudioHelpers.GetSupportedStems(song.folder.FullName);
 
-			GameManager.AudioManager.LoadSong(stems);
+			GameManager.AudioManager.LoadSong(stems, Math.Abs(speed - 1) > float.Epsilon);
 			SongLength = GameManager.AudioManager.AudioLengthF;
 
 			GameUI.Instance.SetLoadingText("Loading chart...");

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -237,10 +237,20 @@ namespace YARG.Settings {
 			public void UseStarpowerFxChange() {
 				GameManager.AudioManager.UseStarpowerFx = useStarpowerFx;
 			}
+			
+			[SettingShowInGame]
+			[SettingLocation("general", 27)]
+			[SettingType("Toggle")]
+			public bool useChipmunkSpeed = false;
+
+			[SettingChangeFunc("useChipmunkSpeed")]
+			public void UseChipmunkSpeedChange() {
+				GameManager.AudioManager.IsChipmunkSpeedup = useChipmunkSpeed;
+			}
 
 			[SettingSpace]
 			[SettingShowInGame]
-			[SettingLocation("general", 27)]
+			[SettingLocation("general", 28)]
 			[SettingType("Toggle")]
 			public bool amIAwesome = false;
 		}


### PR DESCRIPTION
Didn't realise song speedups were already in the game (bottom right text box on the difficulty select apparently lol), so never accounted for them in the audio code.

This PR adds support for speedups, as well as a "Chipmunk Speedups" setting, which will pitch shift the audio when enabled. It is disabled by default as most people don't like the audio pitch shifting when sped up.

Also changed starpower charge drainage to drain relative to the song's speed.