### PR TITLE
Fixed an edge-case bug in windows path names

### DIFF
--- a/Assets/Script/GameManager.cs
+++ b/Assets/Script/GameManager.cs
@@ -54,7 +54,14 @@ namespace YARG {
 
 		private void Start() {
 			updateChecker = GetComponent<UpdateChecker>();
-			PersistentDataPath = Application.persistentDataPath;
+			//this is to handle a strange edge case in path naming in windows.
+			//modern windows can handle / or \ in path names with seemingly one exception, if there is a space in the user name then try forward slash appdata, it will break at the first space so:
+			// c:\users\joe blow\appdata <- okay!
+			// c:/users/joe blow\appdata <- okay!
+			// c:/users/joe blow/appdata <- "Please choose an app to open joe"
+			// so let's just set them all to \ on windows to be sure.
+			// For linux Path.DirectorySeparatorChar should return /, and this should work fine, but this should be double checked once those builds are being worked on
+			PersistentDataPath = Application.persistentDataPath.Replace("/", Path.DirectorySeparatorChar.ToString());
 			Settings.SettingsManager.Init();
 
 			// High polling rate


### PR DESCRIPTION
Windows likes to explode with user names that have spaces, this should fix that. Check the comments for more details