### PR TITLE
fix(YARG.UI): album image not loading on unix systems

### DIFF
--- a/Assets/Script/UI/SelectedSongView.cs
+++ b/Assets/Script/UI/SelectedSongView.cs
@@ -166,7 +166,7 @@ namespace YARG.UI {
 			}
 
 			// Load file
-			using UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(filePath);
+			using UnityWebRequest uwr = UnityWebRequestTexture.GetTexture($"file://{filePath}");
 			yield return uwr.SendWebRequest();
 			var texture = DownloadHandlerTexture.GetContent(uwr);
 


### PR DESCRIPTION
(please someone test this on windows before)

Reference: https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest-url.html#:~:text=If%20the%20input%20URL%20starts%20with%20a%20single%20slash%20(/)%2C%20then%20the%20system%20assumes%20the%20inout%20is%20a%20path%20relative%20to%20the%20current%20domain%20on%20which%20the%20Unity%20application%20is%20running.%20On%20non%2DWebGL%20platforms%2C%20the%20system%20will%20prepend%20http%3A//localhost%20to%20the%20URL.