### PR TITLE
fix(YARG.UI): use system.uri instead of unity built-in

### DIFF
--- a/Assets/Script/UI/SelectedSongView.cs
+++ b/Assets/Script/UI/SelectedSongView.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.IO;
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -166,9 +167,10 @@ namespace YARG.UI {
 			}
 
 			// Load file
-#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
 			
-			using UnityWebRequest uwr = UnityWebRequestTexture.GetTexture($"file://{filePath}");
+			Uri pathUri = new Uri(filePath);
+			using UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(pathUri);
 
 #else
 


### PR DESCRIPTION
apparently UnityWebRequest URL builder still doesn't work well for local files on mac/unix systems (even when prepending file:// before) and some album arts didn't load

also now using system.uri removes the necessity to specify the protocol too