### PR TITLE
Some audio engine tweaks

### DIFF
--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -139,6 +139,10 @@ MonoBehaviour:
     m_Key: rhythmVolume
     m_Metadata:
       m_Items: []
+  - m_Id: 8393437626548224
+    m_Key: useChipmunkSpeed
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -146,6 +146,10 @@ MonoBehaviour:
     m_Localized: Rhythm Volume
     m_Metadata:
       m_Items: []
+  - m_Id: 8393437626548224
+    m_Localized: Chipmunk Speedups
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Fixes localisation not being added for chipmunk speedup setting (Unity didn't save it for some reason when I last PR'd), also fixes a potential memory leak by now auto freeing the source stream of a BassFX stream. Increased mixer thread count to 2 as well.