### PR TITLE
Disable the Quickplay button if no players are added

### DIFF
--- a/Assets/Scenes/MenuScene.unity
+++ b/Assets/Scenes/MenuScene.unity
@@ -881,7 +881,7 @@ PrefabInstance:
     - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
         type: 3}
       propertyPath: m_Name
-      value: MainMenuButton
+      value: Settings
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cccf866ef69cf784b989cd792919610b, type: 3}
@@ -3805,6 +3805,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
+--- !u!114 &344867062 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8708184733134376299, guid: cccf866ef69cf784b989cd792919610b,
+    type: 3}
+  m_PrefabInstance: {fileID: 59632595}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &365708821
 GameObject:
   m_ObjectHideFlags: 0
@@ -8304,7 +8316,7 @@ PrefabInstance:
     - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
         type: 3}
       propertyPath: m_Name
-      value: MainMenuButton
+      value: Credits
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cccf866ef69cf784b989cd792919610b, type: 3}
@@ -8748,6 +8760,12 @@ MonoBehaviour:
   progressBar: {fileID: 1649890904}
   versionText: {fileID: 528723089}
   updateObject: {fileID: 1099876205}
+  menuButtons:
+  - {fileID: 2060644224}
+  - {fileID: 1151438762}
+  - {fileID: 344867062}
+  - {fileID: 1813624069}
+  - {fileID: 1756588822}
 --- !u!1 &882788346
 GameObject:
   m_ObjectHideFlags: 0
@@ -11379,7 +11397,7 @@ PrefabInstance:
     - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
         type: 3}
       propertyPath: m_Name
-      value: MainMenuButton
+      value: Add/Edit Players
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cccf866ef69cf784b989cd792919610b, type: 3}
@@ -11389,6 +11407,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1151438760}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1151438762 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8708184733134376299, guid: cccf866ef69cf784b989cd792919610b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1151438760}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1170408631
 GameObject:
   m_ObjectHideFlags: 0
@@ -16503,7 +16533,7 @@ PrefabInstance:
     - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
         type: 3}
       propertyPath: m_Name
-      value: MainMenuButton
+      value: Exit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cccf866ef69cf784b989cd792919610b, type: 3}
@@ -16513,6 +16543,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1756588820}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1756588822 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8708184733134376299, guid: cccf866ef69cf784b989cd792919610b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1756588820}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1764603578
 GameObject:
   m_ObjectHideFlags: 0
@@ -16772,6 +16814,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1787562866}
   m_CullTransparentMesh: 1
+--- !u!114 &1813624069 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8708184733134376299, guid: cccf866ef69cf784b989cd792919610b,
+    type: 3}
+  m_PrefabInstance: {fileID: 831780705}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1816306047
 GameObject:
   m_ObjectHideFlags: 0
@@ -19021,6 +19075,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2051694766}
   m_CullTransparentMesh: 1
+--- !u!114 &2060644224 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8708184733134376299, guid: cccf866ef69cf784b989cd792919610b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8708184731602617178}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2063024714
 GameObject:
   m_ObjectHideFlags: 0
@@ -19870,7 +19936,12 @@ PrefabInstance:
     - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
         type: 3}
       propertyPath: m_Name
-      value: MainMenuButton
+      value: Quickplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8708184733134376309, guid: cccf866ef69cf784b989cd792919610b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cccf866ef69cf784b989cd792919610b, type: 3}

--- a/Assets/Script/UI/MainMenu.cs
+++ b/Assets/Script/UI/MainMenu.cs
@@ -15,6 +15,14 @@ namespace YARG.UI {
 			private set;
 		}
 
+		private enum ButtonIndex {
+			QUICKPLAY,
+			ADD_EDIT_PLAYERS,
+			SETTINGS,
+			CREDITS,
+			EXIT
+		}
+
 		public SongInfo chosenSong = null;
 
 		[SerializeField]
@@ -54,6 +62,10 @@ namespace YARG.UI {
 
 		private TextMeshProUGUI updateText;
 
+		[Space]
+		[SerializeField]
+		private Button[] menuButtons;
+
 		private bool isUpdateShown;
 
 		private void Start() {
@@ -78,6 +90,13 @@ namespace YARG.UI {
 			// Bind input events
 			foreach (var player in PlayerManager.players) {
 				player.inputStrategy.GenericNavigationEvent += OnGenericNavigation;
+			}
+
+			var quickplayText = menuButtons[(int) ButtonIndex.QUICKPLAY].GetComponentInChildren<TextMeshProUGUI>();
+			if (PlayerManager.players.Count > 0) {
+				quickplayText.text = "QUICKPLAY";
+			} else {
+				quickplayText.text = "<color=#808080>QUICKPLAY<size=50%> (Add a player!)</size></color>";
 			}
 		}
 
@@ -162,8 +181,10 @@ namespace YARG.UI {
 		}
 
 		public void ShowSongSelect() {
-			HideAll();
-			songSelect.gameObject.SetActive(true);
+			if (PlayerManager.players.Count > 0) {
+				HideAll();
+				songSelect.gameObject.SetActive(true);
+			}
 		}
 
 		public void ShowPreSong() {


### PR DESCRIPTION
This prevents errors from the instrument select screen expecting at least one player to be present.

A helpful indicator is provided when the button is disabled:

![image](https://user-images.githubusercontent.com/29052821/233617389-9372367a-8464-4a7f-aea0-33880beac0a4.png)