### PR TITLE
Fix stem volume settings while paused

### DIFF
--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -6,7 +6,7 @@ namespace YARG {
 
 		public SfxSample Sample { get; }
 
-		private readonly BassAudioManager _manager;
+		private readonly IAudioManager _manager;
 		private readonly string _path;
 		private readonly int _playbackCount;
 		
@@ -14,7 +14,7 @@ namespace YARG {
 		
 		private bool _disposed;
 
-		public BassSampleChannel(BassAudioManager manager, string path, int playbackCount, SfxSample sample) {
+		public BassSampleChannel(IAudioManager manager, string path, int playbackCount, SfxSample sample) {
 			_manager = manager;
 			_path = path;
 			_playbackCount = playbackCount;
@@ -45,7 +45,9 @@ namespace YARG {
 				return;
 
 			int channel = Bass.SampleGetChannel(_sfxHandle);
-			Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, _manager.sfxVolume * AudioHelpers.SfxVolume[(int) Sample]);
+			
+			double volume = _manager.GetVolumeSetting(SongStem.Sfx) * AudioHelpers.SfxVolume[(int) Sample];
+			Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, volume);
 
 			Bass.ChannelPlay(channel);
 		}

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -2,14 +2,15 @@ using System;
 using System.Collections.Generic;
 using ManagedBass;
 using ManagedBass.Mix;
-using UnityEngine;
 
 namespace YARG {
 	public class BassStemMixer : IStemMixer {
 
 		public int StemsLoaded { get; private set; }
-
+		
 		public bool IsPlaying { get; private set; }
+		
+		public IReadOnlyDictionary<SongStem, IStemChannel> Channels => _channels;
 
 		public IStemChannel LeadChannel { get; private set; }
 

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -9,6 +9,9 @@ namespace YARG {
 
 		public bool IsAudioLoaded { get; }
 		public bool IsPlaying { get; }
+		
+		public double MasterVolume { get; }
+		public double SfxVolume { get; }
 
 		public double CurrentPositionD { get; }
 		public double AudioLengthD { get; }
@@ -32,6 +35,8 @@ namespace YARG {
 		public void SetStemVolume(SongStem stem, double volume);
 
 		public void UpdateVolumeSetting(SongStem stem, double volume);
+		
+		public double GetVolumeSetting(SongStem stem);
 
 		public void ApplyReverb(SongStem stem, bool reverb);
 

--- a/Assets/Script/Audio/Interfaces/IStemChannel.cs
+++ b/Assets/Script/Audio/Interfaces/IStemChannel.cs
@@ -6,10 +6,12 @@ namespace YARG {
 		public SongStem Stem { get; }
 		public double LengthD { get; }
 		public float LengthF => (float)LengthD;
+		
+		public double Volume { get; }
 
 		public int Load(bool isSpeedUp, float speed);
 		
-		public void SetVolume(double volume);
+		public void SetVolume(double newVolume);
 		
 		public void SetReverb(bool reverb);
 

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace YARG {
 	public interface IStemMixer : IDisposable {
@@ -7,6 +8,8 @@ namespace YARG {
 		
 		public bool IsPlaying { get; }
 		
+		public IReadOnlyDictionary<SongStem, IStemChannel> Channels { get; }
+
 		public IStemChannel LeadChannel { get; }
 		
 		public bool Create();

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -79,7 +79,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 3645699926646784
-    m_Localized: Master Music Volume
+    m_Localized: Master Volume
     m_Metadata:
       m_Items: []
   - m_Id: 3645822882668544
@@ -103,7 +103,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 3646318347411456
-    m_Localized: Other Instruments Volume
+    m_Localized: Song Volume
     m_Metadata:
       m_Items: []
   - m_Id: 3646366187642880


### PR DESCRIPTION
Changing the volume settings for stems in the pause menu did not apply correctly when unpausing. This PR fixes this issue and changes who is responsible for applying the stem setting to the current volume (such as stem muting volumes). The stem itself is now responsible for applying the setting + volume multiplier instead of the caller

Also changed a couple localisation values for better clarity