### PR TITLE
Fix wrong rounding for solo section percentage

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -344,7 +344,7 @@ namespace YARG.PlayMode {
 				);
 				commonTrack.soloText.gameObject.SetActive(true);
 
-				soloHitPercent = Mathf.RoundToInt(soloNotesHit / (float) soloNoteCount * 100f);
+				soloHitPercent = Mathf.FloorToInt(soloNotesHit / (float) soloNoteCount * 100f);
 				commonTrack.soloText.text = $"{soloHitPercent}%\n<size=10><alpha=#66>{soloNotesHit}/{soloNoteCount}</size>";
 			} else if (Play.Instance.SongTime >= SoloSection?.EndTime && Play.Instance.SongTime <= SoloSection?.EndTime + 4) {
 				if (soloHitPercent >= 100f) {


### PR DESCRIPTION
Currently, stuff such as 438/440 notes hit can lead to 100% being wrongly displayed even if not all notes were hit. This fixes that
(mfw the description is longer than the actual fix)