### PR TITLE
Basic event-based input handling

### DIFF
--- a/Assets/Script/Calibrator.cs
+++ b/Assets/Script/Calibrator.cs
@@ -36,10 +36,6 @@ namespace YARG {
 		}
 
 		private void Update() {
-			foreach (var player in PlayerManager.players) {
-				player.inputStrategy.UpdatePlayerMode();
-			}
-
 			// End calibration when the music is done
 			if (state == State.CALIBRATING) {
 				if (!musicPlayer.isPlaying) {

--- a/Assets/Script/Input/DrumsInputStrategy.cs
+++ b/Assets/Script/Input/DrumsInputStrategy.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using YARG.Data;
+using YARG.PlayMode;
 using YARG.Settings;
 
 namespace YARG.Input {
@@ -15,6 +16,8 @@ namespace YARG.Input {
 			"kick",
 			"kick_alt"
 		};
+
+		private List<NoteInfo> botChart;
 
 		public delegate void DrumHitAction(int drum, bool cymbal);
 
@@ -76,11 +79,19 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateBotMode(object rawChart, float songTime) {
-			var chart = (List<NoteInfo>) rawChart;
+		public override void InitializeBotMode(object rawChart) {
+			botChart = (List<NoteInfo>) rawChart;
+		}
 
-			while (chart.Count > botChartIndex && chart[botChartIndex].time <= songTime) {
-				var noteInfo = chart[botChartIndex];
+		protected override void UpdateBotMode() {
+			if (botChart == null) {
+				return;
+			}
+
+			float songTime = Play.Instance.SongTime;
+
+			while (botChart.Count > botChartIndex && botChart[botChartIndex].time <= songTime) {
+				var noteInfo = botChart[botChartIndex];
 				botChartIndex++;
 
 				// Deal with no kicks

--- a/Assets/Script/Input/DrumsInputStrategy.cs
+++ b/Assets/Script/Input/DrumsInputStrategy.cs
@@ -110,14 +110,8 @@ namespace YARG.Input {
 		protected override void UpdateNavigationMode() {
 			CallGenericNavigationEventForButton("yellow_pad", NavigationType.UP);
 			CallGenericNavigationEventForButton("blue_pad", NavigationType.DOWN);
-
-			if (WasMappingPressed("green_pad")) {
-				CallGenericNavigationEvent(NavigationType.PRIMARY, true);
-			}
-
-			if (WasMappingPressed("red_pad")) {
-				CallGenericNavigationEvent(NavigationType.SECONDARY, true);
-			}
+			CallGenericNavigationEventForButton("green_pad", NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton("red_pad", NavigationType.SECONDARY);
 		}
 
 		public override string[] GetAllowedInstruments() {

--- a/Assets/Script/Input/DrumsInputStrategy.cs
+++ b/Assets/Script/Input/DrumsInputStrategy.cs
@@ -24,7 +24,7 @@ namespace YARG.Input {
 			return MAPPING_NAMES;
 		}
 
-		public override void UpdatePlayerMode() {
+		protected override void UpdatePlayerMode() {
 			// Deal with drum inputs
 
 			if (WasMappingPressed("red_pad")) {
@@ -96,7 +96,7 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateNavigationMode() {
+		protected override void UpdateNavigationMode() {
 			CallGenericNavigationEventForButton("yellow_pad", NavigationType.UP);
 			CallGenericNavigationEventForButton("blue_pad", NavigationType.DOWN);
 

--- a/Assets/Script/Input/FiveFretInputStrategy.cs
+++ b/Assets/Script/Input/FiveFretInputStrategy.cs
@@ -99,17 +99,9 @@ namespace YARG.Input {
 			CallGenericNavigationEventForButton("strumUp", NavigationType.UP);
 			CallGenericNavigationEventForButton("strumDown", NavigationType.DOWN);
 
-			if (WasMappingPressed("green")) {
-				CallGenericNavigationEvent(NavigationType.PRIMARY, true);
-			}
-
-			if (WasMappingPressed("red")) {
-				CallGenericNavigationEvent(NavigationType.SECONDARY, true);
-			}
-
-			if (WasMappingPressed("yellow")) {
-				CallGenericNavigationEvent(NavigationType.TERTIARY, true);
-			}
+			CallGenericNavigationEventForButton("green", NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton("red", NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton("yellow", NavigationType.TERTIARY);
 
 			if (WasMappingPressed("pause")) {
 				CallPauseEvent();

--- a/Assets/Script/Input/FiveFretInputStrategy.cs
+++ b/Assets/Script/Input/FiveFretInputStrategy.cs
@@ -25,7 +25,7 @@ namespace YARG.Input {
 			return MAPPING_NAMES;
 		}
 
-		public override void UpdatePlayerMode() {
+		protected override void UpdatePlayerMode() {
 			// Deal with fret inputs
 
 			for (int i = 0; i < 5; i++) {
@@ -88,7 +88,7 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateNavigationMode() {
+		protected override void UpdateNavigationMode() {
 			CallGenericNavigationEventForButton("strumUp", NavigationType.UP);
 			CallGenericNavigationEventForButton("strumDown", NavigationType.DOWN);
 

--- a/Assets/Script/Input/FiveFretInputStrategy.cs
+++ b/Assets/Script/Input/FiveFretInputStrategy.cs
@@ -48,14 +48,10 @@ namespace YARG.Input {
 				CallGenericCalbirationEvent();
 			}
 
-			// Starpower & Pause
+			// Starpower
 
 			if (WasMappingPressed("starpower")) {
 				CallStarpowerEvent();
-			}
-
-			if (WasMappingPressed("pause")) {
-				CallPauseEvent();
 			}
 		}
 

--- a/Assets/Script/Input/FiveFretInputStrategy.cs
+++ b/Assets/Script/Input/FiveFretInputStrategy.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using YARG.Data;
+using YARG.PlayMode;
 
 namespace YARG.Input {
 	public class FiveFretInputStrategy : InputStrategy {
@@ -15,6 +16,8 @@ namespace YARG.Input {
 			"pause"
 		};
 
+		private List<NoteInfo> botChart;
+
 		public delegate void FretChangeAction(bool pressed, int fret);
 		public delegate void StrumAction();
 
@@ -23,6 +26,10 @@ namespace YARG.Input {
 
 		public override string[] GetMappingNames() {
 			return MAPPING_NAMES;
+		}
+
+		public override void InitializeBotMode(object rawChart) {
+			botChart = (List<NoteInfo>) rawChart;
 		}
 
 		protected override void UpdatePlayerMode() {
@@ -55,11 +62,15 @@ namespace YARG.Input {
 			}
 		}
 
-		public override void UpdateBotMode(object rawChart, float songTime) {
-			var chart = (List<NoteInfo>) rawChart;
+		protected override void UpdateBotMode() {
+			if (botChart == null) {
+				return;
+			}
+
+			float songTime = Play.Instance.SongTime;
 
 			bool resetForChord = false;
-			while (chart.Count > botChartIndex && chart[botChartIndex].time <= songTime) {
+			while (botChart.Count > botChartIndex && botChart[botChartIndex].time <= songTime) {
 				// Release old frets
 				if (!resetForChord) {
 					for (int i = 0; i < 5; i++) {
@@ -68,7 +79,7 @@ namespace YARG.Input {
 					resetForChord = true;
 				}
 
-				var noteInfo = chart[botChartIndex];
+				var noteInfo = botChart[botChartIndex];
 				botChartIndex++;
 
 				// Skip fret press if open note

--- a/Assets/Script/Input/GHDrumsInputStrategy.cs
+++ b/Assets/Script/Input/GHDrumsInputStrategy.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using YARG.Data;
+using YARG.PlayMode;
 using YARG.Settings;
 
 namespace YARG.Input {
@@ -13,6 +14,8 @@ namespace YARG.Input {
 			"kick",
 			"kick_alt"
 		};
+
+		private List<NoteInfo> botChart;
 
 		public delegate void DrumHitAction(int drum);
 
@@ -64,11 +67,19 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateBotMode(object rawChart, float songTime) {
-			var chart = (List<NoteInfo>) rawChart;
+		public override void InitializeBotMode(object rawChart) {
+			botChart = (List<NoteInfo>) rawChart;
+		}
 
-			while (chart.Count > botChartIndex && chart[botChartIndex].time <= songTime) {
-				var noteInfo = chart[botChartIndex];
+		protected override void UpdateBotMode() {
+			if (botChart == null) {
+				return;
+			}
+
+			float songTime = Play.Instance.SongTime;
+
+			while (botChart.Count > botChartIndex && botChart[botChartIndex].time <= songTime) {
+				var noteInfo = botChart[botChartIndex];
 				botChartIndex++;
 
 				if (noteInfo.fret == 5 && SettingsManager.GetSettingValue<bool>("noKicks")) {

--- a/Assets/Script/Input/GHDrumsInputStrategy.cs
+++ b/Assets/Script/Input/GHDrumsInputStrategy.cs
@@ -22,7 +22,7 @@ namespace YARG.Input {
 			return MAPPING_NAMES;
 		}
 
-		public override void UpdatePlayerMode() {
+		protected override void UpdatePlayerMode() {
 			// Deal with drum inputs
 
 			if (WasMappingPressed("red_pad")) {
@@ -83,7 +83,7 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateNavigationMode() {
+		protected override void UpdateNavigationMode() {
 			// TODO
 		}
 

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -133,7 +133,7 @@ namespace YARG.Input {
 		/// <summary>
 		/// Updates the player mode (normal mode) for this particular InputStrategy.
 		/// </summary>
-		public abstract void UpdatePlayerMode();
+		protected abstract void UpdatePlayerMode();
 
 		/// <summary>
 		/// Updates the bot mode for this particular InputStrategy.
@@ -146,7 +146,7 @@ namespace YARG.Input {
 		/// <summary>
 		/// Updates the navigation mode (menu mode) for this particular InputStrategy.
 		/// </summary>
-		public abstract void UpdateNavigationMode();
+		protected abstract void UpdateNavigationMode();
 
 		protected void CallStarpowerEvent() {
 			StarpowerEvent?.Invoke(this);
@@ -185,6 +185,12 @@ namespace YARG.Input {
 			foreach (var mapping in inputMappings) {
 				bool previous = inputStates[mapping.Key].current;
 				inputStates[mapping.Key] = (previous, IsControlPressed(mapping.Value));
+			}
+
+			// Update navigation and player input
+			if (!botMode) {
+				UpdateNavigationMode();
+				UpdatePlayerMode();
 			}
 		}
 

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -75,10 +75,6 @@ namespace YARG.Input {
 		}
 
 		public void Enable() {
-			if (_inputDevice == null) {
-				return;
-			}
-
 			// Bind events
 			GameManager.OnUpdate += EventUpdateLoop;
 
@@ -92,10 +88,6 @@ namespace YARG.Input {
 		}
 
 		public void Disable() {
-			if (_inputDevice == null) {
-				return;
-			}
-
 			// Unbind events
 			GameManager.OnUpdate -= EventUpdateLoop;
 
@@ -131,6 +123,12 @@ namespace YARG.Input {
 		}
 
 		/// <summary>
+		/// Initializes the bot mode for this particular InputStrategy.
+		/// </summary>
+		/// <param name="chart">A reference to the current chart.</param>
+		public abstract void InitializeBotMode(object chart);
+
+		/// <summary>
 		/// Updates the player mode (normal mode) for this particular InputStrategy.
 		/// </summary>
 		protected abstract void UpdatePlayerMode();
@@ -138,10 +136,7 @@ namespace YARG.Input {
 		/// <summary>
 		/// Updates the bot mode for this particular InputStrategy.
 		/// </summary>
-		/// <param name="chart">A reference to the current chart.</param>
-		/// <param name="songTime">The song time in seconds.</param>
-		/// <param name="chosenInstrument">The instrument that the bot is playing.</param>
-		public abstract void UpdateBotMode(object chart, float songTime);
+		protected abstract void UpdateBotMode();
 
 		/// <summary>
 		/// Updates the navigation mode (menu mode) for this particular InputStrategy.
@@ -187,9 +182,11 @@ namespace YARG.Input {
 				inputStates[mapping.Key] = (previous, IsControlPressed(mapping.Value));
 			}
 
-			// Update navigation and player input
-			if (!botMode) {
-				UpdateNavigationMode();
+			// Update inputs
+			UpdateNavigationMode();
+			if (botMode) {
+				UpdateBotMode();
+			} else {
 				UpdatePlayerMode();
 			}
 		}

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -6,6 +6,9 @@ using UnityEngine.InputSystem.Controls;
 
 namespace YARG.Input {
 	public abstract class InputStrategy {
+		public const float PRESS_THRESHOLD = 0.75f; // TODO: Remove once control calibration is added
+		public const int INVALID_MIC_INDEX = -1;
+
 		public bool botMode;
 		protected int botChartIndex;
 
@@ -31,7 +34,7 @@ namespace YARG.Input {
 			}
 		}
 
-		public int microphoneIndex = -1;
+		public int microphoneIndex = INVALID_MIC_INDEX;
 
 		// Temporary for MIDI
 		private OccurrenceList<string> midiPressed = new();

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -21,6 +21,8 @@ namespace YARG.Input {
 		private const int WINDOW_SIZE = 64;
 		private const float THRESHOLD = 0.05f;
 
+		private List<LyricInfo> botChart;
+
 		private float[] samples = new float[SAMPLE_SCAN_SIZE];
 
 		private float updateTimer;
@@ -209,12 +211,21 @@ namespace YARG.Input {
 			return DF(optimizedSamples, time, lag) / sum * lag;
 		}
 
-		public override void UpdateBotMode(object rawChart, float songTime) {
-			var chart = (List<LyricInfo>) rawChart;
+		public override void InitializeBotMode(object rawChart) {
+			botChart = (List<LyricInfo>) rawChart;
+		}
+
+
+		protected override void UpdateBotMode() {
+			if (botChart == null) {
+				return;
+			}
+
+			float songTime = Play.Instance.SongTime;
 
 			// Get the next lyric
-			while (chart.Count > botChartIndex && chart[botChartIndex].time <= songTime) {
-				botLyricInfo = chart[botChartIndex];
+			while (botChart.Count > botChartIndex && botChart[botChartIndex].time <= songTime) {
+				botLyricInfo = botChart[botChartIndex];
 				botChartIndex++;
 			}
 

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -52,7 +52,7 @@ namespace YARG.Input {
 		}
 
 		public override void UpdatePlayerMode() {
-			if (microphoneIndex == -1) {
+			if (microphoneIndex == INVALID_MIC_INDEX) {
 				return;
 			}
 

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -51,7 +51,7 @@ namespace YARG.Input {
 			return new string[0];
 		}
 
-		public override void UpdatePlayerMode() {
+		protected override void UpdatePlayerMode() {
 			if (microphoneIndex == INVALID_MIC_INDEX) {
 				return;
 			}
@@ -241,7 +241,7 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateNavigationMode() {
+		protected override void UpdateNavigationMode() {
 			// TODO
 		}
 

--- a/Assets/Script/Input/RealGuitarInputStrategy.cs
+++ b/Assets/Script/Input/RealGuitarInputStrategy.cs
@@ -4,6 +4,7 @@ using PlasticBand.Devices;
 using UnityEngine;
 using UnityEngine.InputSystem.Controls;
 using YARG.Data;
+using YARG.PlayMode;
 
 namespace YARG.Input {
 	public class RealGuitarInputStrategy : InputStrategy {
@@ -27,6 +28,8 @@ namespace YARG.Input {
 
 		public event FretChangeAction FretChangeEvent;
 		public event StrumAction StrumEvent;
+
+		private List<NoteInfo> botChart;
 
 		private int[] fretCache = new int[6];
 		private float[] velocityCache = new float[6];
@@ -106,11 +109,20 @@ namespace YARG.Input {
 			};
 		}
 
-		public override void UpdateBotMode(object rawChart, float songTime) {
-			var chart = (List<NoteInfo>) rawChart;
+		public override void InitializeBotMode(object rawChart) {
+			botChart = (List<NoteInfo>) rawChart;
+		}
 
-			while (chart.Count > botChartIndex && chart[botChartIndex].time <= songTime) {
-				var note = chart[botChartIndex];
+
+		protected override void UpdateBotMode() {
+			if (botChart == null) {
+				return;
+			}
+
+			float songTime = Play.Instance.SongTime;
+
+			while (botChart.Count > botChartIndex && botChart[botChartIndex].time <= songTime) {
+				var note = botChart[botChartIndex];
 
 				// Press correct frets
 				for (int i = 0; i < 6; i++) {

--- a/Assets/Script/Input/RealGuitarInputStrategy.cs
+++ b/Assets/Script/Input/RealGuitarInputStrategy.cs
@@ -38,7 +38,7 @@ namespace YARG.Input {
 			return new string[0];
 		}
 
-		public override void UpdatePlayerMode() {
+		protected override void UpdatePlayerMode() {
 			if (InputDevice is not ProGuitar input) {
 				return;
 			}
@@ -138,7 +138,7 @@ namespace YARG.Input {
 			CallStarpowerEvent();
 		}
 
-		public override void UpdateNavigationMode() {
+		protected override void UpdateNavigationMode() {
 			// TODO
 		}
 

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -151,9 +151,6 @@ namespace YARG.PlayMode {
 		private void Update() {
 			// Don't update if paused
 			if (Play.Instance.Paused) {
-				// Update navigation for pause menu
-				player.inputStrategy.UpdateNavigationMode();
-
 				return;
 			}
 

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -122,6 +122,7 @@ namespace YARG.PlayMode {
 			player.inputStrategy.StarpowerEvent += StarpowerAction;
 			player.inputStrategy.PauseEvent += PauseAction;
 			Play.BeatEvent += BeatAction;
+			Play.OnPauseToggle += PauseToggled;
 
 			player.lastScore = null;
 
@@ -146,6 +147,7 @@ namespace YARG.PlayMode {
 			player.inputStrategy.StarpowerEvent -= StarpowerAction;
 			player.inputStrategy.PauseEvent -= PauseAction;
 			Play.BeatEvent -= BeatAction;
+			Play.OnPauseToggle -= PauseToggled;
 		}
 
 		private void Update() {
@@ -296,6 +298,8 @@ namespace YARG.PlayMode {
 		private void PauseAction() {
 			Play.Instance.Paused = !Play.Instance.Paused;
 		}
+
+		protected abstract void PauseToggled(bool pause);
 
 		private void UpdateInfo() {
 			// Update text

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -52,6 +52,10 @@ namespace YARG.PlayMode {
 				ghStrat.DrumHitEvent += GHDrumHitAction;
 			}
 
+			if (input.botMode) {
+				input.InitializeBotMode(Chart);
+			}
+
 			// GH vs RB
 
 			kickIndex = fiveLaneMode ? 5 : 4;
@@ -95,11 +99,6 @@ namespace YARG.PlayMode {
 		}
 
 		protected override void UpdateTrack() {
-			// Update input strategy
-			if (input.botMode) {
-				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			}
-
 			// Ignore everything else until the song starts
 			if (!Play.Instance.SongStarted) {
 				return;

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -189,6 +189,22 @@ namespace YARG.PlayMode {
 			}
 		}
 
+		protected override void PauseToggled(bool pause) {
+			if (!pause) {
+				if (input is DrumsInputStrategy drumStrat) {
+					drumStrat.DrumHitEvent += DrumHitAction;
+				} else if (input is GHDrumsInputStrategy ghStrat) {
+					ghStrat.DrumHitEvent += GHDrumHitAction;
+				}
+			} else {
+				if (input is DrumsInputStrategy drumStrat) {
+					drumStrat.DrumHitEvent -= DrumHitAction;
+				} else if (input is GHDrumsInputStrategy ghStrat) {
+					ghStrat.DrumHitEvent -= GHDrumHitAction;
+				}
+			}
+		}
+
 		private void GHDrumHitAction(int drum) {
 			DrumHitAction(drum, false);
 		}

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -98,8 +98,6 @@ namespace YARG.PlayMode {
 			// Update input strategy
 			if (input.botMode) {
 				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			} else {
-				input.UpdatePlayerMode();
 			}
 
 			// Ignore everything else until the song starts

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -479,6 +479,16 @@ namespace YARG.PlayMode {
 			return true;
 		}
 
+		protected override void PauseToggled(bool pause) {
+			if (!pause) {
+				input.FretChangeEvent += FretChangedAction;
+				input.StrumEvent += StrumAction;
+			} else {
+				input.FretChangeEvent -= FretChangedAction;
+				input.StrumEvent -= StrumAction;
+			}
+		}
+
 		private void FretChangedAction(bool pressed, int fret) {
 			latestInput = Play.Instance.SongTime;
 			latestInputIsStrum = false;

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -83,8 +83,6 @@ namespace YARG.PlayMode {
 			// Update input strategy
 			if (input.botMode) {
 				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			} else {
-				input.UpdatePlayerMode();
 			}
 
 			// Ignore everything else until the song starts

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -51,6 +51,10 @@ namespace YARG.PlayMode {
 			input.FretChangeEvent += FretChangedAction;
 			input.StrumEvent += StrumAction;
 
+			if (input.botMode) {
+				input.InitializeBotMode(Chart);
+			}
+
 			// Color frets
 			for (int i = 0; i < 5; i++) {
 				var fret = frets[i].GetComponent<Fret>();
@@ -80,11 +84,6 @@ namespace YARG.PlayMode {
 		}
 
 		protected override void UpdateTrack() {
-			// Update input strategy
-			if (input.botMode) {
-				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			}
-
 			// Ignore everything else until the song starts
 			if (!Play.Instance.SongStarted) {
 				return;

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -425,8 +425,6 @@ namespace YARG.PlayMode {
 
 					botChartIndices++;
 					botChartIndices %= charts.Count;
-				} else {
-					micInput.UpdatePlayerMode();
 				}
 
 				// Get the correct range

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -346,6 +346,11 @@ namespace YARG.PlayMode {
 				return;
 			}
 
+			// Ignore if paused
+			if (!Play.Instance.Paused) {
+				return;
+			}
+
 			// Call "OnSongStart"
 			if (!onSongStartCalled) {
 				onSongStartCalled = true;

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -324,8 +324,18 @@ namespace YARG.PlayMode {
 			}
 
 			// Set up sing progresses
+			int botChartIndex = 0;
 			foreach (var playerInfo in micInputs) {
 				playerInfo.singProgresses = new float[harmonyCount];
+				var player = playerInfo.player;
+				var micInput = (MicInputStrategy) player.inputStrategy;
+
+				// Update inputs
+				if (micInput.botMode) {
+					micInput.InitializeBotMode(charts[botChartIndex]);
+					botChartIndex++;
+					botChartIndex %= charts.Count;
+				}
 			}
 
 			// Set up current lyrics
@@ -419,18 +429,9 @@ namespace YARG.PlayMode {
 			}
 
 			// Update player specific stuff
-			int botChartIndices = 0;
 			foreach (var playerInfo in micInputs) {
 				var player = playerInfo.player;
 				var micInput = (MicInputStrategy) player.inputStrategy;
-
-				// Update inputs
-				if (micInput.botMode) {
-					micInput.UpdateBotMode(charts[botChartIndices], Play.Instance.SongTime);
-
-					botChartIndices++;
-					botChartIndices %= charts.Count;
-				}
 
 				// Get the correct range
 				float correctRange = player.chosenDifficulty switch {

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -175,7 +175,7 @@ namespace YARG.PlayMode {
 				}
 
 				// Skip if the player hasn't assigned a mic
-				if (micStrategy.microphoneIndex == -1 && !micStrategy.botMode) {
+				if (micStrategy.microphoneIndex == InputStrategy.INVALID_MIC_INDEX && !micStrategy.botMode) {
 					continue;
 				}
 

--- a/Assets/Script/PlayMode/RealGuitarTrack.cs
+++ b/Assets/Script/PlayMode/RealGuitarTrack.cs
@@ -218,6 +218,16 @@ namespace YARG.PlayMode {
 			}
 		}
 
+		protected override void PauseToggled(bool pause) {
+			if (!pause) {
+				input.FretChangeEvent += FretChangedAction;
+				input.StrumEvent += StrumAction;
+			} else {
+				input.FretChangeEvent -= FretChangedAction;
+				input.StrumEvent -= StrumAction;
+			}
+		}
+
 		private bool NoteStrummed(NoteInfo note) {
 			int extras = 0;
 			for (int str = 0; str < note.stringFrets.Length; str++) {

--- a/Assets/Script/PlayMode/RealGuitarTrack.cs
+++ b/Assets/Script/PlayMode/RealGuitarTrack.cs
@@ -86,8 +86,6 @@ namespace YARG.PlayMode {
 			// Update input strategy
 			if (input.botMode) {
 				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			} else {
-				input.UpdatePlayerMode();
 			}
 
 			// Ignore everything else until the song starts

--- a/Assets/Script/PlayMode/RealGuitarTrack.cs
+++ b/Assets/Script/PlayMode/RealGuitarTrack.cs
@@ -53,6 +53,10 @@ namespace YARG.PlayMode {
 			input.FretChangeEvent += FretChangedAction;
 			input.StrumEvent += StrumAction;
 
+			if (input.botMode) {
+				input.InitializeBotMode(Chart);
+			}
+
 			// Color particles
 
 			for (int i = 0; i < 6; i++) {
@@ -83,11 +87,6 @@ namespace YARG.PlayMode {
 		}
 
 		protected override void UpdateTrack() {
-			// Update input strategy
-			if (input.botMode) {
-				input.UpdateBotMode(Chart, Play.Instance.SongTime);
-			}
-
 			// Ignore everything else until the song starts
 			if (!Play.Instance.SongStarted) {
 				return;

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -272,6 +272,7 @@ namespace YARG.UI {
 			var player = new PlayerManager.Player() {
 				inputStrategy = inputStrategy
 			};
+			player.inputStrategy.Enable();
 			PlayerManager.players.Add(player);
 
 			// Set name

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -1,3 +1,4 @@
+using System;
 using Minis;
 using TMPro;
 using UnityEngine;
@@ -40,69 +41,45 @@ namespace YARG.UI {
 
 		private State state = State.SELECT_DEVICE;
 
-		private (InputDevice, int)? selectedDevice;
-		private bool botMode;
-		private string playerName;
-		private InputStrategy inputStrategy;
+		private (InputDevice device, int micIndex)? selectedDevice = null;
+		private bool botMode = false;
+		private string playerName = null;
+		private InputStrategy inputStrategy = null;
 
-		private string currentBindUpdate;
+		private string currentBindUpdate = null;
+		private TextMeshProUGUI currentBindText = null;
 
 		private void OnEnable() {
+			playerNameField.text = null;
+
+			StartSelectDevice();
+		}
+
+		private void OnDisable() {
+			playerNameField.text = null;
+
 			selectedDevice = null;
 			botMode = false;
 			inputStrategy = null;
 			playerName = null;
 
 			currentBindUpdate = null;
-
-			playerNameField.text = null;
-
-			UpdateSelectDevice();
-		}
-
-		private void OnDisable() {
-			currentBindUpdate = null;
+			currentBindText = null;
 		}
 
 		private void Update() {
-			if (state == State.BIND && currentBindUpdate != null) {
-
-				// Cancel
-				if (Keyboard.current.escapeKey.wasPressedThisFrame) {
-					currentBindUpdate = null;
+			switch (state) {
+				case State.BIND:
 					UpdateBind();
-					return;
-				}
-
-				if (inputStrategy.InputDevice is not MidiDevice) {
-					foreach (var control in selectedDevice?.Item1.allControls) {
-						// Skip "any key" (as that would always be detected)
-						if (control is AnyKeyControl) {
-							continue;
-						}
-
-						if (control is not ButtonControl buttonControl) {
-							continue;
-						}
-
-						if (!buttonControl.wasPressedThisFrame) {
-							continue;
-						}
-
-						// Set mapping and stop waiting
-						inputStrategy.SetMappingInputControl(currentBindUpdate, control);
-						currentBindUpdate = null;
-
-						// Refresh
-						UpdateBind();
-						break;
-					}
-				}
+					break;
+				default:
+					break;
 			}
 		}
 
-		private void UpdateSubHeader() {
-			subHeader.text = state switch {
+		private void UpdateState(State newState) {
+			state = newState;
+			subHeader.text = newState switch {
 				State.SELECT_DEVICE => "Step 1 - Select Device",
 				State.CONFIGURE => "Step 2 - Configure",
 				State.BIND => "Step 3 - Bind",
@@ -116,12 +93,10 @@ namespace YARG.UI {
 			bindContainer.SetActive(false);
 		}
 
-		private void UpdateSelectDevice() {
+		private void StartSelectDevice() {
 			HideAll();
 			selectDeviceContainer.SetActive(true);
-
-			state = State.SELECT_DEVICE;
-			UpdateSubHeader();
+			UpdateState(State.SELECT_DEVICE);
 
 			// Destroy old devices
 			foreach (Transform t in devicesContainer) {
@@ -129,45 +104,43 @@ namespace YARG.UI {
 			}
 
 			// Add bot button
-			var botGo = Instantiate(deviceButtonPrefab, devicesContainer);
-			botGo.GetComponentInChildren<TextMeshProUGUI>().text = "Create a <color=#0c7027><b>BOT</b></color>";
-			botGo.GetComponentInChildren<Button>().onClick.AddListener(() => {
+			var botButton = Instantiate(deviceButtonPrefab, devicesContainer);
+			botButton.GetComponentInChildren<TextMeshProUGUI>().text = "Create a <color=#0c7027><b>BOT</b></color>";
+			botButton.GetComponentInChildren<Button>().onClick.AddListener(() => {
 				selectedDevice = (null, -1);
 				botMode = true;
-				UpdateConfigure();
+				StartConfigure();
 			});
 
 			// Add devices
 			foreach (var device in InputSystem.devices) {
-				var go = Instantiate(deviceButtonPrefab, devicesContainer);
-				go.GetComponentInChildren<TextMeshProUGUI>().text = $"<b>{device.displayName}</b> ({device.deviceId})";
-				go.GetComponentInChildren<Button>().onClick.AddListener(() => {
+				var button = Instantiate(deviceButtonPrefab, devicesContainer);
+				button.GetComponentInChildren<TextMeshProUGUI>().text = $"<b>{device.displayName}</b> ({device.deviceId})";
+				button.GetComponentInChildren<Button>().onClick.AddListener(() => {
 					selectedDevice = (device, -1);
-					UpdateConfigure();
+					StartConfigure();
 				});
 			}
 
 			// Add mics
 			for (int i = 0; i < Microphone.devices.Length; i++) {
-				var go = Instantiate(deviceButtonPrefab, devicesContainer);
-				go.GetComponentInChildren<TextMeshProUGUI>().text = $"(MIC) <b>{Microphone.devices[i]}</b>";
+				var button = Instantiate(deviceButtonPrefab, devicesContainer);
+				button.GetComponentInChildren<TextMeshProUGUI>().text = $"(MIC) <b>{Microphone.devices[i]}</b>";
 
 				int capture = i;
-				go.GetComponentInChildren<Button>().onClick.AddListener(() => {
+				button.GetComponentInChildren<Button>().onClick.AddListener(() => {
 					selectedDevice = (null, capture);
-					UpdateConfigure();
+					StartConfigure();
 				});
 			}
 		}
 
-		private void UpdateConfigure() {
+		private void StartConfigure() {
 			HideAll();
 			configureContainer.SetActive(true);
+			UpdateState(State.CONFIGURE);
 
-			state = State.CONFIGURE;
-			UpdateSubHeader();
-
-			if (selectedDevice?.Item2 != -1) {
+			if (selectedDevice?.micIndex != -1) {
 				// Set to MIC if the selected device is a MIC
 				inputStrategyDropdown.value = 1;
 			} else {
@@ -182,14 +155,14 @@ namespace YARG.UI {
 				2 => new RealGuitarInputStrategy(),
 				3 => new DrumsInputStrategy(),
 				4 => new GHDrumsInputStrategy(),
-				_ => throw new System.Exception("Unreachable.")
+				_ => throw new Exception("Invalid input strategy type!")
 			};
 
-			if (selectedDevice?.Item1 == null) {
+			if (selectedDevice?.device == null) {
 				inputStrategy.InputDevice = null;
-				inputStrategy.microphoneIndex = selectedDevice?.Item2 ?? -1;
+				inputStrategy.microphoneIndex = selectedDevice?.micIndex ?? -1;
 			} else {
-				inputStrategy.InputDevice = selectedDevice?.Item1;
+				inputStrategy.InputDevice = selectedDevice?.device;
 				inputStrategy.microphoneIndex = -1;
 			}
 
@@ -197,29 +170,26 @@ namespace YARG.UI {
 
 			playerName = playerNameField.text;
 
-			if (inputStrategy.InputDevice is MidiDevice midiDevice) {
-				midiDevice.onWillNoteOn += OnNote;
-			}
-
 			// Try to load bindings
 			if (inputStrategy.InputDevice != null) {
 				InputBindSerializer.LoadBindsFromSave(inputStrategy);
 			}
 
-			UpdateBind();
+			StartBind();
 		}
 
-		private void UpdateBind() {
-			if (inputStrategy.GetMappingNames().Length <= 0 || botMode) {
+		private string GetMappingText(string binding)
+			=> $"<b>{binding}:</b> {inputStrategy.GetMappingInputControl(binding)?.displayName ?? "None"}";
+
+		private void StartBind() {
+			if (inputStrategy.GetMappingNames().Length < 1 || botMode) {
 				DoneBind();
 				return;
 			}
 
 			HideAll();
 			bindContainer.SetActive(true);
-
-			state = State.BIND;
-			UpdateSubHeader();
+			UpdateState(State.BIND);
 
 			// Destroy old bindings
 			foreach (Transform t in bindingsContainer) {
@@ -228,21 +198,28 @@ namespace YARG.UI {
 
 			// Add bindings
 			foreach (var binding in inputStrategy.GetMappingNames()) {
-				var go = Instantiate(deviceButtonPrefab, bindingsContainer);
+				var button = Instantiate(deviceButtonPrefab, bindingsContainer);
 
-				var text = go.GetComponentInChildren<TextMeshProUGUI>();
-				text.text = $"<b>{binding}:</b> {inputStrategy.GetMappingInputControl(binding)?.displayName ?? "None"}";
+				var text = button.GetComponentInChildren<TextMeshProUGUI>();
+				text.text = GetMappingText(binding);
 
-				go.GetComponentInChildren<Button>().onClick.AddListener(() => {
+				button.GetComponentInChildren<Button>().onClick.AddListener(() => {
 					if (currentBindUpdate == null) {
 						currentBindUpdate = binding;
+						currentBindText = text;
 						text.text = $"<b>{binding}:</b> Waiting for input... (Escape to cancel)";
 					}
 				});
 			}
+
+			// Temp for MIDI
+			if (inputStrategy.InputDevice is MidiDevice midiDevice) {
+				midiDevice.onWillNoteOn += OnNote;
+			}
 		}
 
-		private void OnNote(MidiNoteControl control, float v) {
+		// Workaround to avoid very short note events not registering correctly
+		private void OnNote(MidiNoteControl control, float velocity) {
 			if (currentBindUpdate == null) {
 				return;
 			}
@@ -252,10 +229,47 @@ namespace YARG.UI {
 			currentBindUpdate = null;
 
 			// Refresh
-			UpdateBind();
+			DoneBind();
+		}
+
+		private void UpdateBind() {
+			if (currentBindUpdate == null) {
+				return;
+			}
+
+			// Cancel
+			if (Keyboard.current.escapeKey.wasPressedThisFrame) {
+				currentBindText.text = GetMappingText(currentBindUpdate);
+				currentBindText = null;
+				currentBindUpdate = null;
+				return;
+			}
+
+			if (inputStrategy.InputDevice is not MidiDevice) { // Temp for MIDI
+				foreach (var control in selectedDevice?.device.allControls) {
+					// Skip "any key" (as that would always be detected)
+					if (control is AnyKeyControl) {
+						continue;
+					}
+
+					if (control is not ButtonControl buttonControl || !buttonControl.wasPressedThisFrame) {
+						continue;
+					}
+
+					// Set mapping and update text
+					inputStrategy.SetMappingInputControl(currentBindUpdate, control);
+					currentBindText.text = GetMappingText(currentBindUpdate);
+
+					// Stop waiting
+					currentBindUpdate = null;
+					currentBindText = null;
+					break;
+				}
+			}
 		}
 
 		public void DoneBind() {
+			// Temp for MIDI
 			if (inputStrategy.InputDevice is MidiDevice midiDevice) {
 				midiDevice.onWillNoteOn -= OnNote;
 			}

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -107,7 +107,7 @@ namespace YARG.UI {
 			var botButton = Instantiate(deviceButtonPrefab, devicesContainer);
 			botButton.GetComponentInChildren<TextMeshProUGUI>().text = "Create a <color=#0c7027><b>BOT</b></color>";
 			botButton.GetComponentInChildren<Button>().onClick.AddListener(() => {
-				selectedDevice = (null, -1);
+				selectedDevice = (null, InputStrategy.INVALID_MIC_INDEX);
 				botMode = true;
 				StartConfigure();
 			});
@@ -117,7 +117,7 @@ namespace YARG.UI {
 				var button = Instantiate(deviceButtonPrefab, devicesContainer);
 				button.GetComponentInChildren<TextMeshProUGUI>().text = $"<b>{device.displayName}</b> ({device.deviceId})";
 				button.GetComponentInChildren<Button>().onClick.AddListener(() => {
-					selectedDevice = (device, -1);
+					selectedDevice = (device, InputStrategy.INVALID_MIC_INDEX);
 					StartConfigure();
 				});
 			}
@@ -140,7 +140,7 @@ namespace YARG.UI {
 			configureContainer.SetActive(true);
 			UpdateState(State.CONFIGURE);
 
-			if (selectedDevice?.micIndex != -1) {
+			if (selectedDevice?.micIndex != InputStrategy.INVALID_MIC_INDEX) {
 				// Set to MIC if the selected device is a MIC
 				inputStrategyDropdown.value = 1;
 			} else {
@@ -160,10 +160,10 @@ namespace YARG.UI {
 
 			if (selectedDevice?.device == null) {
 				inputStrategy.InputDevice = null;
-				inputStrategy.microphoneIndex = selectedDevice?.micIndex ?? -1;
+				inputStrategy.microphoneIndex = selectedDevice?.micIndex ?? InputStrategy.INVALID_MIC_INDEX;
 			} else {
 				inputStrategy.InputDevice = selectedDevice?.device;
-				inputStrategy.microphoneIndex = -1;
+				inputStrategy.microphoneIndex = InputStrategy.INVALID_MIC_INDEX;
 			}
 
 			inputStrategy.botMode = botMode;

--- a/Assets/Script/UI/DifficultySelect.cs
+++ b/Assets/Script/UI/DifficultySelect.cs
@@ -78,13 +78,6 @@ namespace YARG.UI {
 			}
 		}
 
-		private void Update() {
-			// Update player navigation
-			foreach (var player in PlayerManager.players) {
-				player.inputStrategy.UpdateNavigationMode();
-			}
-		}
-
 		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
 			if (!firstPressed) {
 				return;

--- a/Assets/Script/UI/DifficultySelect.cs
+++ b/Assets/Script/UI/DifficultySelect.cs
@@ -78,8 +78,8 @@ namespace YARG.UI {
 			}
 		}
 
-		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
-			if (!firstPressed) {
+		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
+			if (!pressed) {
 				return;
 			}
 

--- a/Assets/Script/UI/MainMenu.cs
+++ b/Assets/Script/UI/MainMenu.cs
@@ -115,8 +115,8 @@ namespace YARG.UI {
 			}
 		}
 
-		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
-			if (!firstPressed) {
+		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
+			if (!pressed) {
 				return;
 			}
 

--- a/Assets/Script/UI/MainMenu.cs
+++ b/Assets/Script/UI/MainMenu.cs
@@ -106,11 +106,6 @@ namespace YARG.UI {
 				return;
 			}
 
-			// Update player navigation
-			foreach (var player in PlayerManager.players) {
-				player.inputStrategy.UpdateNavigationMode();
-			}
-
 			if (!isUpdateShown && GameManager.Instance.updateChecker.IsOutOfDate) {
 				isUpdateShown = true;
 

--- a/Assets/Script/UI/PauseMenu.cs
+++ b/Assets/Script/UI/PauseMenu.cs
@@ -46,8 +46,8 @@ namespace YARG.UI {
 			}
 		}
 
-		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
-			if (!firstPressed) {
+		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
+			if (!pressed) {
 				return;
 			}
 

--- a/Assets/Script/UI/PauseMenu.cs
+++ b/Assets/Script/UI/PauseMenu.cs
@@ -26,8 +26,6 @@ namespace YARG.UI {
 		}
 
 		private void OnEnable() {
-			// Note that player navigation is updated in AbstractTrack
-
 			// Bind input events
 			foreach (var player in PlayerManager.players) {
 				player.inputStrategy.GenericNavigationEvent += OnGenericNavigation;

--- a/Assets/Script/UI/PlayerSection.cs
+++ b/Assets/Script/UI/PlayerSection.cs
@@ -35,6 +35,8 @@ namespace YARG.UI {
 
 		public void DeletePlayer() {
 			PlayerManager.players.Remove(player);
+			player.inputStrategy.Disable();
+			player = null;
 			Destroy(gameObject);
 		}
 

--- a/Assets/Script/UI/PostSong.cs
+++ b/Assets/Script/UI/PostSong.cs
@@ -111,11 +111,6 @@ namespace YARG.UI {
 			if (Keyboard.current.enterKey.wasPressedThisFrame) {
 				MainMenu.Instance.ShowMainMenu();
 			}
-
-			// Update player navigation
-			foreach (var player in PlayerManager.players) {
-				player.inputStrategy.UpdateNavigationMode();
-			}
 		}
 
 		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {

--- a/Assets/Script/UI/PostSong.cs
+++ b/Assets/Script/UI/PostSong.cs
@@ -113,8 +113,8 @@ namespace YARG.UI {
 			}
 		}
 
-		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
-			if (!firstPressed) {
+		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
+			if (!pressed) {
 				return;
 			}
 

--- a/Assets/Script/UI/SongSelect.cs
+++ b/Assets/Script/UI/SongSelect.cs
@@ -45,6 +45,8 @@ namespace YARG.UI {
 		private List<SongView> songViewsBefore = new();
 		private List<SongView> songViewsAfter = new();
 
+		private NavigationType direction;
+		private bool directionHeld = false;
 		private float inputTimer = 0f;
 
 		// Will be set in UpdateSearch
@@ -161,6 +163,14 @@ namespace YARG.UI {
 			// Update input timer
 
 			inputTimer -= Time.deltaTime;
+			if (inputTimer <= 0f && directionHeld) {
+				switch (direction) {
+					case NavigationType.UP: MoveView(-1); break;
+					case NavigationType.DOWN: MoveView(1); break;
+				}
+
+				inputTimer = INPUT_REPEAT_TIME;
+			}
 
 			// Up arrow
 
@@ -196,29 +206,29 @@ namespace YARG.UI {
 			}
 		}
 
-		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {
-			if (inputTimer <= 0f || firstPressed) {
-				if (navigationType == NavigationType.UP) {
-					inputTimer = firstPressed ? INPUT_REPEAT_COOLDOWN : INPUT_REPEAT_TIME;
-					MoveView(-1);
-				} else if (navigationType == NavigationType.DOWN) {
-					inputTimer = firstPressed ? INPUT_REPEAT_COOLDOWN : INPUT_REPEAT_TIME;
-					MoveView(1);
+		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
+			if (navigationType == NavigationType.UP || navigationType == NavigationType.DOWN) {
+				if (!directionHeld || direction != navigationType) {
+					direction = navigationType;
+					directionHeld = pressed;
+					inputTimer = INPUT_REPEAT_COOLDOWN;
 				}
 			}
 
-			if (!firstPressed) {
+			if (!pressed) {
 				return;
 			}
 
-			if (navigationType == NavigationType.PRIMARY) {
-				selectedSongView.PlaySong();
-			} else if (navigationType == NavigationType.SECONDARY) {
-				Back();
-			} else if (navigationType == NavigationType.TERTIARY) {
-				if (songs.Count > 0) {
-					searchField.text = $"artist:{songs[selectedSongIndex].song.artistName}";
-				}
+			switch (navigationType) {
+				case NavigationType.UP: MoveView(-1); break;
+				case NavigationType.DOWN: MoveView(1); break;
+				case NavigationType.PRIMARY: selectedSongView.PlaySong(); break;
+				case NavigationType.SECONDARY: Back(); break;
+				case NavigationType.TERTIARY:
+					if (songs.Count > 0) {
+						searchField.text = $"artist:{songs[selectedSongIndex].song.artistName}";
+					}
+					break;
 			}
 		}
 

--- a/Assets/Script/UI/SongSelect.cs
+++ b/Assets/Script/UI/SongSelect.cs
@@ -194,11 +194,6 @@ namespace YARG.UI {
 			} else if (scroll < 0f) {
 				MoveView(1);
 			}
-
-			// Update player navigation
-			foreach (var player in PlayerManager.players) {
-				player.inputStrategy.UpdateNavigationMode();
-			}
 		}
 
 		private void OnGenericNavigation(NavigationType navigationType, bool firstPressed) {


### PR DESCRIPTION
Most aspects of input handling are now driven by `InputSystem.onEvent`. This is the first step towards FPS-independent input (this is in *no way* a comprehensive implementation for that however, just to be clear).

Input strategies are now fully event-based, and will update themselves automatically. They can be enabled and disabled as needed, which will prevent them from processing any updates. They are automatically enabled when added to the player list, and automatically disabled when removed.

Control binding and the song select menu's default keyboard navigation are also now fully event-based.

Some additional changes I made along the way:
- AddPlayer has been cleaned up quite a bit.
- Invalid microphone index value has been made into a constant.
- Input strategies now store the previous and current states of controls manually.
  - This will assist with axis support down the line, particularly with using axis inputs as button inputs.
- MIDI device workarounds have been removed, as they should no longer be needed.
- Song select's default keyboard navigation is now only enabled when the keyboard is not being used with a player.
  - This avoids double-input issues if the up and down arrows are used as bindings.
- Song select's default keyboard navigation now uses Escape as a binding for Back.