### PR TITLE
lefty flip pro drums red cymbal input fix

### DIFF
--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -237,7 +237,11 @@ namespace YARG.PlayMode {
 						drum = kickIndex == 4 ? 1 : 2;
 						break;
 					case 3:
-						drum = kickIndex == 4 ? 0 : 1;
+						// lefty flip on pro drums means physically moving the green cymbal above the red snare
+						// so while the position on the chart has changed, the input object is the same
+						if (!cymbal){
+							drum = kickIndex == 4 ? 0 : 1;
+						}
 						break;
 					case 4:
 						if (kickIndex == 5) {


### PR DESCRIPTION
Fixes #173 

In the previous implementation, the lefty flip red cymbal input was being read as a regular red cymbal, which doesn't exist. 
Pro Drums lefty flip implies the player has moved the Green cymbal above the Red snare, so whilst the chart has flipped, and so have the inputs, that specific input stays the same because the input object was physically moved.