### PR TITLE
Rework input handling to allow for axis support

### DIFF
--- a/Assets/Script/Input/ControlBinding.cs
+++ b/Assets/Script/Input/ControlBinding.cs
@@ -3,8 +3,17 @@ using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 
 namespace YARG.Input {
+    public enum BindingType {
+        BUTTON,
+        AXIS
+    }
+
     public class ControlBinding {
 		public const float DEFAULT_PRESS_THRESHOLD = 0.75f; // TODO: Remove once control calibration is added
+
+        public BindingType Type { get; }
+        public string DisplayName { get; }
+        public string BindingKey { get; }
 
         private InputControl<float> _control;
         public InputControl<float> Control {
@@ -21,6 +30,12 @@ namespace YARG.Input {
         public (float previous, float current) State => _state;
 
         private float pressPoint = DEFAULT_PRESS_THRESHOLD;
+
+        public ControlBinding(BindingType type, string displayName, string bindingKey) {
+            Type = type;
+            DisplayName = displayName;
+            BindingKey = bindingKey;
+        }
 
         public bool IsPressed() {
             // Ignore if unmapped

--- a/Assets/Script/Input/ControlBinding.cs
+++ b/Assets/Script/Input/ControlBinding.cs
@@ -1,0 +1,67 @@
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
+
+namespace YARG.Input {
+    public class ControlBinding {
+		public const float DEFAULT_PRESS_THRESHOLD = 0.75f; // TODO: Remove once control calibration is added
+
+        private InputControl<float> _control;
+        public InputControl<float> Control {
+            get => _control;
+            set {
+                _control = value;
+                if (value is ButtonControl button) {
+                    pressPoint = button.pressPointOrDefault;
+                }
+            }
+        }
+
+        private (float previous, float current) _state;
+        public (float previous, float current) State => _state;
+
+        private float pressPoint = DEFAULT_PRESS_THRESHOLD;
+
+        public bool IsPressed() {
+            // Ignore if unmapped
+            if (_control == null) {
+                return false;
+            }
+
+            return _state.current >= pressPoint;
+        }
+
+        public bool WasPressed() {
+            // Ignore if unmapped
+            if (_control == null) {
+                return false;
+            }
+
+            return _state.previous < pressPoint && _state.current >= pressPoint;
+        }
+
+        public bool WasReleased() {
+            // Ignore if unmapped
+            if (_control == null) {
+                return false;
+            }
+
+            return _state.previous >= pressPoint && _state.current < pressPoint;
+        }
+
+        public void UpdateState(InputEventPtr eventPtr) {
+            // Ignore if unmapped
+            if (_control == null) {
+                return;
+            }
+
+            // Progress state history forward
+            _state.previous = _state.current;
+            // Don't check pressed state unless there was a value change
+            // Controls not changed in a delta state event (which MIDI devices use) will report the wrong value
+            if (_control.HasValueChangeInEvent(eventPtr)) {
+                _state.current = _control.ReadValueFromEvent(eventPtr);
+            }
+        }
+    }
+}

--- a/Assets/Script/Input/ControlBinding.cs.meta
+++ b/Assets/Script/Input/ControlBinding.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb4ba3c6ccb732a46a5380363fef2f40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Input/DrumsInputStrategy.cs
+++ b/Assets/Script/Input/DrumsInputStrategy.cs
@@ -5,17 +5,17 @@ using YARG.Settings;
 
 namespace YARG.Input {
 	public class DrumsInputStrategy : InputStrategy {
-		public static readonly string[] MAPPING_NAMES = new string[] {
-			"red_pad",
-			"yellow_pad",
-			"blue_pad",
-			"green_pad",
-			"yellow_cymbal",
-			"blue_cymbal",
-			"green_cymbal",
-			"kick",
-			"kick_alt"
-		};
+		public const string RED_PAD = "red_pad";
+		public const string YELLOW_PAD = "yellow_pad";
+		public const string BLUE_PAD = "blue_pad";
+		public const string GREEN_PAD = "green_pad";
+
+		public const string YELLOW_CYMBAL = "yellow_cymbal";
+		public const string BLUE_CYMBAL = "blue_cymbal";
+		public const string GREEN_CYMBAL = "green_cymbal";
+
+		public const string KICK = "kick";
+		public const string KICK_ALT = "kick_alt";
 
 		private List<NoteInfo> botChart;
 
@@ -23,54 +23,64 @@ namespace YARG.Input {
 
 		public event DrumHitAction DrumHitEvent;
 
-		public override string[] GetMappingNames() {
-			return MAPPING_NAMES;
-		}
+		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
+			{ RED_PAD,       new(BindingType.BUTTON, "Red Pad", RED_PAD) },
+			{ YELLOW_PAD,    new(BindingType.BUTTON, "Yellow Pad", YELLOW_PAD) },
+			{ BLUE_PAD,      new(BindingType.BUTTON, "Blue Pad", BLUE_PAD) },
+			{ GREEN_PAD,     new(BindingType.BUTTON, "Green Pad", GREEN_PAD) },
+
+			{ YELLOW_CYMBAL, new(BindingType.BUTTON, "Yellow Cymbal", YELLOW_CYMBAL) },
+			{ BLUE_CYMBAL,   new(BindingType.BUTTON, "Blue Cymbal", BLUE_CYMBAL) },
+			{ GREEN_CYMBAL,  new(BindingType.BUTTON, "Green Cymbal", GREEN_CYMBAL) },
+
+			{ KICK,          new(BindingType.BUTTON, "Kick", KICK) },
+			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) }
+		};
 
 		protected override void UpdatePlayerMode() {
 			// Deal with drum inputs
 
-			if (WasMappingPressed("red_pad")) {
+			if (WasMappingPressed(RED_PAD)) {
 				DrumHitEvent?.Invoke(0, false);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("yellow_pad")) {
+			if (WasMappingPressed(YELLOW_PAD)) {
 				DrumHitEvent?.Invoke(1, false);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("blue_pad")) {
+			if (WasMappingPressed(BLUE_PAD)) {
 				DrumHitEvent?.Invoke(2, false);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("green_pad")) {
+			if (WasMappingPressed(GREEN_PAD)) {
 				DrumHitEvent?.Invoke(3, false);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("yellow_cymbal")) {
+			if (WasMappingPressed(YELLOW_CYMBAL)) {
 				DrumHitEvent?.Invoke(1, true);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("blue_cymbal")) {
+			if (WasMappingPressed(BLUE_CYMBAL)) {
 				DrumHitEvent?.Invoke(2, true);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("green_cymbal")) {
+			if (WasMappingPressed(GREEN_CYMBAL)) {
 				DrumHitEvent?.Invoke(3, true);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("kick")) {
+			if (WasMappingPressed(KICK)) {
 				DrumHitEvent?.Invoke(4, false);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("kick_alt")) {
+			if (WasMappingPressed(KICK_ALT)) {
 				DrumHitEvent?.Invoke(4, false);
 				CallGenericCalbirationEvent();
 			}
@@ -106,10 +116,10 @@ namespace YARG.Input {
 		}
 
 		protected override void UpdateNavigationMode() {
-			CallGenericNavigationEventForButton("yellow_pad", NavigationType.UP);
-			CallGenericNavigationEventForButton("blue_pad", NavigationType.DOWN);
-			CallGenericNavigationEventForButton("green_pad", NavigationType.PRIMARY);
-			CallGenericNavigationEventForButton("red_pad", NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton(YELLOW_PAD, NavigationType.UP);
+			CallGenericNavigationEventForButton(BLUE_PAD, NavigationType.DOWN);
+			CallGenericNavigationEventForButton(GREEN_PAD, NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton(RED_PAD, NavigationType.SECONDARY);
 		}
 
 		public override string[] GetAllowedInstruments() {

--- a/Assets/Script/Input/FiveFretInputStrategy.cs
+++ b/Assets/Script/Input/FiveFretInputStrategy.cs
@@ -4,17 +4,17 @@ using YARG.PlayMode;
 
 namespace YARG.Input {
 	public class FiveFretInputStrategy : InputStrategy {
-		public static readonly string[] MAPPING_NAMES = new string[] {
-			"green",
-			"red",
-			"yellow",
-			"blue",
-			"orange",
-			"strumUp",
-			"strumDown",
-			"starpower",
-			"pause"
-		};
+		public const string GREEN = "green";
+		public const string RED = "red";
+		public const string YELLOW = "yellow";
+		public const string BLUE = "blue";
+		public const string ORANGE = "orange";
+
+		public const string STRUM_UP = "strum_up";
+		public const string STRUM_DOWN = "strum_down";
+	
+		public const string STAR_POWER = "star_power";
+		public const string PAUSE = "pause";
 
 		private List<NoteInfo> botChart;
 
@@ -24,40 +24,56 @@ namespace YARG.Input {
 		public event FretChangeAction FretChangeEvent;
 		public event StrumAction StrumEvent;
 
-		public override string[] GetMappingNames() {
-			return MAPPING_NAMES;
-		}
+		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
+			{ GREEN,      new(BindingType.BUTTON, "Green", GREEN) },
+			{ RED,        new(BindingType.BUTTON, "Red", RED) },
+			{ YELLOW,     new(BindingType.BUTTON, "Yellow", YELLOW) },
+			{ BLUE,       new(BindingType.BUTTON, "Blue", BLUE) },
+			{ ORANGE,     new(BindingType.BUTTON, "Orange", ORANGE) },
+
+			{ STRUM_UP,   new(BindingType.BUTTON, "Strum Up", STRUM_UP) },
+			{ STRUM_DOWN, new(BindingType.BUTTON, "Strum Down", STRUM_DOWN) },
+
+			{ STAR_POWER, new(BindingType.BUTTON, "Star Power", STAR_POWER) },
+			{ PAUSE,      new(BindingType.BUTTON, "Pause", PAUSE) },
+		};
 
 		public override void InitializeBotMode(object rawChart) {
 			botChart = (List<NoteInfo>) rawChart;
 		}
 
 		protected override void UpdatePlayerMode() {
-			// Deal with fret inputs
-
-			for (int i = 0; i < 5; i++) {
-				if (WasMappingPressed(MAPPING_NAMES[i])) {
-					FretChangeEvent?.Invoke(true, i);
-				} else if (WasMappingReleased(MAPPING_NAMES[i])) {
-					FretChangeEvent?.Invoke(false, i);
+			void HandleFret(string mapping, int index) {
+				if (WasMappingPressed(mapping)) {
+					FretChangeEvent?.Invoke(true, index);
+				} else if (WasMappingReleased(mapping)) {
+					FretChangeEvent?.Invoke(false, index);
 				}
 			}
 
+			// Deal with fret inputs
+
+			HandleFret(GREEN, 0);
+			HandleFret(RED, 1);
+			HandleFret(YELLOW, 2);
+			HandleFret(BLUE, 3);
+			HandleFret(ORANGE, 4);
+
 			// Deal with strumming
 
-			if (WasMappingPressed("strumUp")) {
+			if (WasMappingPressed(STRUM_UP)) {
 				StrumEvent?.Invoke();
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("strumDown")) {
+			if (WasMappingPressed(STRUM_DOWN)) {
 				StrumEvent?.Invoke();
 				CallGenericCalbirationEvent();
 			}
 
 			// Starpower
 
-			if (WasMappingPressed("starpower")) {
+			if (WasMappingPressed(STAR_POWER)) {
 				CallStarpowerEvent();
 			}
 		}
@@ -96,14 +112,14 @@ namespace YARG.Input {
 		}
 
 		protected override void UpdateNavigationMode() {
-			CallGenericNavigationEventForButton("strumUp", NavigationType.UP);
-			CallGenericNavigationEventForButton("strumDown", NavigationType.DOWN);
+			CallGenericNavigationEventForButton(STRUM_UP, NavigationType.UP);
+			CallGenericNavigationEventForButton(STRUM_DOWN, NavigationType.DOWN);
 
-			CallGenericNavigationEventForButton("green", NavigationType.PRIMARY);
-			CallGenericNavigationEventForButton("red", NavigationType.SECONDARY);
-			CallGenericNavigationEventForButton("yellow", NavigationType.TERTIARY);
+			CallGenericNavigationEventForButton(GREEN, NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton(RED, NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton(YELLOW, NavigationType.TERTIARY);
 
-			if (WasMappingPressed("pause")) {
+			if (WasMappingPressed(PAUSE)) {
 				CallPauseEvent();
 			}
 		}

--- a/Assets/Script/Input/GHDrumsInputStrategy.cs
+++ b/Assets/Script/Input/GHDrumsInputStrategy.cs
@@ -5,15 +5,14 @@ using YARG.Settings;
 
 namespace YARG.Input {
 	public class GHDrumsInputStrategy : InputStrategy {
-		public static readonly string[] MAPPING_NAMES = new string[] {
-			"red_pad",
-			"yellow_cymbal",
-			"blue_pad",
-			"orange_cymbal",
-			"green_pad",
-			"kick",
-			"kick_alt"
-		};
+		public const string RED_PAD = "red_pad";
+		public const string YELLOW_CYMBAL = "yellow_cymbal";
+		public const string BLUE_PAD = "blue_pad";
+		public const string ORANGE_CYMBAL = "orange_cymbal";
+		public const string GREEN_PAD = "green_pad";
+
+		public const string KICK = "kick";
+		public const string KICK_ALT = "kick_alt";
 
 		private List<NoteInfo> botChart;
 
@@ -21,44 +20,51 @@ namespace YARG.Input {
 
 		public event DrumHitAction DrumHitEvent;
 
-		public override string[] GetMappingNames() {
-			return MAPPING_NAMES;
-		}
+		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
+			{ RED_PAD,       new(BindingType.BUTTON, "Red Pad", RED_PAD) },
+			{ YELLOW_CYMBAL, new(BindingType.BUTTON, "Yellow Cymbal", YELLOW_CYMBAL) },
+			{ BLUE_PAD,      new(BindingType.BUTTON, "Blue Pad", BLUE_PAD) },
+			{ ORANGE_CYMBAL, new(BindingType.BUTTON, "Orange Cymbal", ORANGE_CYMBAL) },
+			{ GREEN_PAD,     new(BindingType.BUTTON, "Green Pad", GREEN_PAD) },
+
+			{ KICK,          new(BindingType.BUTTON, "Kick", KICK) },
+			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) }
+		};
 
 		protected override void UpdatePlayerMode() {
 			// Deal with drum inputs
 
-			if (WasMappingPressed("red_pad")) {
+			if (WasMappingPressed(RED_PAD)) {
 				DrumHitEvent?.Invoke(0);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("yellow_cymbal")) {
+			if (WasMappingPressed(YELLOW_CYMBAL)) {
 				DrumHitEvent?.Invoke(1);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("blue_pad")) {
+			if (WasMappingPressed(BLUE_PAD)) {
 				DrumHitEvent?.Invoke(2);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("orange_cymbal")) {
+			if (WasMappingPressed(ORANGE_CYMBAL)) {
 				DrumHitEvent?.Invoke(3);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("green_pad")) {
+			if (WasMappingPressed(GREEN_PAD)) {
 				DrumHitEvent?.Invoke(4);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("kick")) {
+			if (WasMappingPressed(KICK)) {
 				DrumHitEvent?.Invoke(5);
 				CallGenericCalbirationEvent();
 			}
 
-			if (WasMappingPressed("kick_alt")) {
+			if (WasMappingPressed(KICK_ALT)) {
 				DrumHitEvent?.Invoke(5);
 				CallGenericCalbirationEvent();
 			}

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -208,6 +208,8 @@ namespace YARG.Input {
 		public static bool IsControlPressed(InputControl control) {
 			if (control is ButtonControl button) {
 				return button.isPressed;
+			} else if (control is AxisControl axis) {
+				return axis.IsActuated(PRESS_THRESHOLD);
 			}
 
 			return false;
@@ -216,6 +218,8 @@ namespace YARG.Input {
 		public static bool IsControlPressed(InputControl control, InputEventPtr eventPtr) {
 			if (control is ButtonControl button) {
 				return button.IsValueConsideredPressed(button.ReadValueFromEvent(eventPtr));
+			} else if (control is AxisControl axis) {
+				return axis.ReadValueFromEvent(eventPtr) >= PRESS_THRESHOLD;
 			}
 
 			return false;

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -34,7 +34,8 @@ namespace YARG.Input {
 		/// <summary>
 		/// A list of the controls that correspond to each mapping.
 		/// </summary>
-		protected Dictionary<string, ControlBinding> inputMappings = new();
+		protected Dictionary<string, ControlBinding> inputMappings;
+		public IReadOnlyDictionary<string, ControlBinding> Mappings => inputMappings;
 
 		public bool Enabled { get; private set; }
 
@@ -65,10 +66,8 @@ namespace YARG.Input {
 		public event GenericNavigationAction GenericNavigationEvent;
 
 		public InputStrategy() {
-			// Add keys for each input mapping
-			foreach (var key in GetMappingNames()) {
-				inputMappings.Add(key, new());
-			}
+			// Initialize mappings
+			inputMappings = GetMappings();
 		}
 
 		public void Enable() {
@@ -93,7 +92,7 @@ namespace YARG.Input {
 		/// <returns>
 		/// The input mapping keys that will be present in <see cref="inputMappings"/>
 		/// </returns>
-		public abstract string[] GetMappingNames();
+		protected virtual Dictionary<string, ControlBinding> GetMappings() => new();
 
 		/// <returns>
 		/// An array of the allow instruments for the input strategy.

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -218,6 +218,14 @@ namespace YARG.Input {
 			return inputMappings[key].WasReleased();
 		}
 
+		protected float GetMappingValue(string key) {
+			return inputMappings[key].State.current;
+		}
+
+		protected float GetPreviousMappingValue(string key) {
+			return inputMappings[key].State.previous;
+		}
+
 		public InputControl<float> GetMappingInputControl(string name) {
 			return inputMappings[name].Control;
 		}

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -48,10 +48,6 @@ namespace YARG.Input {
 			SAMPLE_SCAN_SIZE = (int) (TARGET_SIZE * (float) AudioSettings.outputSampleRate / TARGET_SIZE_REF);
 		}
 
-		public override string[] GetMappingNames() {
-			return new string[0];
-		}
-
 		protected override void UpdatePlayerMode() {
 			if (microphoneIndex == INVALID_MIC_INDEX) {
 				return;

--- a/Assets/Script/Input/RealGuitarInputStrategy.cs
+++ b/Assets/Script/Input/RealGuitarInputStrategy.cs
@@ -37,10 +37,6 @@ namespace YARG.Input {
 		private float? stringGroupingTimer = null;
 		private StrumFlag stringGroupingFlag = StrumFlag.NONE;
 
-		public override string[] GetMappingNames() {
-			return new string[0];
-		}
-
 		protected override void UpdatePlayerMode() {
 			if (InputDevice is not ProGuitar input) {
 				return;

--- a/Assets/Script/Serialization/InputBindSerializer.cs
+++ b/Assets/Script/Serialization/InputBindSerializer.cs
@@ -50,16 +50,16 @@ namespace YARG.Serialization {
 				}
 
 				// Set binds
-				foreach (var binding in inputStrategy.GetMappingNames()) {
-					if (!inputBindSave.binds.ContainsKey(binding)) {
+				foreach (var binding in inputStrategy.Mappings.Values) {
+					if (!inputBindSave.binds.ContainsKey(binding.BindingKey)) {
 						continue;
 					}
 
-					var control = InputControlPath.TryFindControl(inputStrategy.InputDevice, inputBindSave.binds[binding]);
+					var control = InputControlPath.TryFindControl(inputStrategy.InputDevice, inputBindSave.binds[binding.BindingKey]);
 					if (control is not InputControl<float> floatControl) {
 						continue;
 					}
-					inputStrategy.SetMappingInputControl(binding, floatControl);
+					inputStrategy.SetMappingInputControl(binding.BindingKey, floatControl);
 				}
 			} catch (Exception e) {
 				Debug.LogWarning("Failed to load input binds from JSON. Ignoring.");
@@ -101,13 +101,13 @@ namespace YARG.Serialization {
 
 				// Save binds
 				inputBindSave.binds.Clear();
-				foreach (var binding in inputStrategy.GetMappingNames()) {
-					var control = inputStrategy.GetMappingInputControl(binding);
+				foreach (var binding in inputStrategy.Mappings.Values) {
+					var control = binding.Control;
 					if (control == null) {
 						continue;
 					}
 
-					inputBindSave.binds.Add(binding, control.path);
+					inputBindSave.binds.Add(binding.BindingKey, control.path);
 				}
 
 				// Save to JSON

--- a/Assets/Script/Serialization/InputBindSerializer.cs
+++ b/Assets/Script/Serialization/InputBindSerializer.cs
@@ -56,7 +56,10 @@ namespace YARG.Serialization {
 					}
 
 					var control = InputControlPath.TryFindControl(inputStrategy.InputDevice, inputBindSave.binds[binding]);
-					inputStrategy.SetMappingInputControl(binding, control);
+					if (control is not InputControl<float> floatControl) {
+						continue;
+					}
+					inputStrategy.SetMappingInputControl(binding, floatControl);
 				}
 			} catch (Exception e) {
 				Debug.LogWarning("Failed to load input binds from JSON. Ignoring.");

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -242,7 +242,7 @@ namespace YARG.UI {
 						continue;
 					}
 
-					if (control is not ButtonControl buttonControl || !buttonControl.isPressed) {
+					if (!InputStrategy.IsControlPressed(control)) {
 						continue;
 					}
 

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -227,16 +227,24 @@ namespace YARG.UI {
 					return;
 				}
 
-				// Ignore if not from the selected device or from the keyboard
-				if (eventPtr.deviceId != device.deviceId && eventPtr.deviceId != Keyboard.current.deviceId) {
+				// Ignore if not from the selected device
+				if (eventPtr.deviceId != device.deviceId) {
+					// Check if cancelling
+					if (eventPtr.deviceId == Keyboard.current.deviceId) {
+						var esc = Keyboard.current.escapeKey;
+						if (esc.IsValueConsideredPressed(esc.ReadValueFromEvent(eventPtr))) {
+							CancelBind();
+						}
+					}
 					return;
 				}
 
-				// Cancel
-				if ((device as Keyboard ?? Keyboard.current).escapeKey.isPressed) {
-					currentBindText.text = GetMappingText(currentBindUpdate);
-					currentBindText = null;
-					currentBindUpdate = null;
+				// Handle cancelling
+				if (device is Keyboard keyboard) {
+					var esc = keyboard.escapeKey;
+					if (esc.IsValueConsideredPressed(esc.ReadValueFromEvent(eventPtr))) {
+						CancelBind();
+					}
 					return;
 				}
 
@@ -262,13 +270,14 @@ namespace YARG.UI {
 		}
 
 		private void SetBind(InputControl<float> control) {
-			// Set mapping and update text
 			inputStrategy.SetMappingInputControl(currentBindUpdate.BindingKey, control);
-			currentBindText.text = GetMappingText(currentBindUpdate);
+			CancelBind();
+		}
 
-			// Stop waiting
-			currentBindUpdate = null;
+		private void CancelBind() {
+			currentBindText.text = GetMappingText(currentBindUpdate);
 			currentBindText = null;
+			currentBindUpdate = null;
 		}
 
 		public void DoneBind() {

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -47,7 +47,7 @@ namespace YARG.UI {
 		private string playerName = null;
 		private InputStrategy inputStrategy = null;
 
-		private string currentBindUpdate = null;
+		private ControlBinding currentBindUpdate = null;
 		private TextMeshProUGUI currentBindText = null;
 		private IDisposable currentDeviceListener = null;
 
@@ -172,11 +172,11 @@ namespace YARG.UI {
 			StartBind();
 		}
 
-		private string GetMappingText(string binding)
-			=> $"<b>{binding}:</b> {inputStrategy.GetMappingInputControl(binding)?.displayName ?? "None"}";
+		private string GetMappingText(ControlBinding binding)
+			=> $"<b>{binding.DisplayName}:</b> {inputStrategy.GetMappingInputControl(binding.BindingKey)?.displayName ?? "None"}";
 
 		private void StartBind() {
-			if (inputStrategy.GetMappingNames().Length < 1 || botMode) {
+			if (inputStrategy.Mappings.Count < 1 || botMode) {
 				DoneBind();
 				return;
 			}
@@ -197,7 +197,7 @@ namespace YARG.UI {
 			}
 
 			// Add bindings
-			foreach (var binding in inputStrategy.GetMappingNames()) {
+			foreach (var binding in inputStrategy.Mappings.Values) {
 				var button = Instantiate(deviceButtonPrefab, bindingsContainer);
 
 				var text = button.GetComponentInChildren<TextMeshProUGUI>();
@@ -207,7 +207,7 @@ namespace YARG.UI {
 					if (currentBindUpdate == null) {
 						currentBindUpdate = binding;
 						currentBindText = text;
-						text.text = $"<b>{binding}:</b> Waiting for input... (Escape to cancel)";
+						text.text = $"<b>{binding.DisplayName}:</b> Waiting for input... (Escape to cancel)";
 					}
 				});
 			}
@@ -247,7 +247,7 @@ namespace YARG.UI {
 					}
 
 					// Set mapping and update text
-					inputStrategy.SetMappingInputControl(currentBindUpdate, floatControl);
+					inputStrategy.SetMappingInputControl(currentBindUpdate.BindingKey, floatControl);
 					currentBindText.text = GetMappingText(currentBindUpdate);
 
 					// Stop waiting

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -237,17 +237,17 @@ namespace YARG.UI {
 				}
 
 				foreach (var control in selectedDevice?.device.allControls) {
-					// Skip "any key" (as that would always be detected)
-					if (control is AnyKeyControl) {
+					// Skip "any key" (as that would always be detected), along with controls that don't return floats
+					if (control is AnyKeyControl || control is not InputControl<float> floatControl) {
 						continue;
 					}
 
-					if (!InputStrategy.IsControlPressed(control)) {
+					if (!InputStrategy.IsControlPressed(floatControl)) {
 						continue;
 					}
 
 					// Set mapping and update text
-					inputStrategy.SetMappingInputControl(currentBindUpdate, control);
+					inputStrategy.SetMappingInputControl(currentBindUpdate, floatControl);
 					currentBindText.text = GetMappingText(currentBindUpdate);
 
 					// Stop waiting

--- a/Assets/Script/UI/SongSelect.cs
+++ b/Assets/Script/UI/SongSelect.cs
@@ -83,9 +83,9 @@ namespace YARG.UI {
 					microphoneIndex = -1,
 					botMode = false
 				};
-				keyboardHandler.SetMappingInputControl("strumUp", keyboard.upArrowKey);
-				keyboardHandler.SetMappingInputControl("strumDown", keyboard.downArrowKey);
-				keyboardHandler.SetMappingInputControl("red", keyboard.escapeKey);
+				keyboardHandler.SetMappingInputControl(FiveFretInputStrategy.STRUM_UP, keyboard.upArrowKey);
+				keyboardHandler.SetMappingInputControl(FiveFretInputStrategy.STRUM_DOWN, keyboard.downArrowKey);
+				keyboardHandler.SetMappingInputControl(FiveFretInputStrategy.RED, keyboard.escapeKey);
 			}
 		}
 


### PR DESCRIPTION
Summary:
- InputStrategy now operates in terms of `InputControl<float>` rather than just `InputControl`.
- Axis inputs are now mappable as controls, and can function as either axis or button inputs.
  - Currently the activation threshold for axes has a hardcoded default, needs configuration added.
- Buttons can also theoretically function as axes, though this also needs some behavior configuration as well.
- *Important note!* Some mapping strings were changed for consistency reasons, so controls previously mapped to those will need to be re-mapped.

This PR does not implement any functionality that relies on axis support, such as whammy. Wanted to split things up a bit so it's not all one big PR lol

Additional features/fixes:
- The control mapper can now detect when multiple controls have been activated in the same state update, and prompt the user to select which one to use.
  - This should probably have a small time period to accumulate activated controls during so that things activated close together but not at the same time can also be resolved.
- Using Escape to cancel mapping no longer causes exceptions to be thrown due to incorrect handling of device IDs.