### PR TITLE
Skip songs with errors loading song.ini when filling the song list

### DIFF
--- a/Assets/Script/Serialization/SongIni.cs
+++ b/Assets/Script/Serialization/SongIni.cs
@@ -40,7 +40,7 @@ namespace YARG.Serialization {
 					section = data["Song"];
 				} else {
 					Debug.LogError($"No `song` section found in `{song.RootFolder}`.");
-					return;
+					throw new ArgumentException($"No `song` section found in `{song.RootFolder}`.");
 				}
 
 				// Set basic info
@@ -142,8 +142,6 @@ namespace YARG.Serialization {
 					}
 				}
 			} catch (Exception e) {
-				Debug.LogError($"Failed to parse song.ini for `{song.RootFolder}`.");
-				Debug.LogException(e);
 				throw e;
 			}
 		}

--- a/Assets/Script/Serialization/SongIni.cs
+++ b/Assets/Script/Serialization/SongIni.cs
@@ -144,6 +144,7 @@ namespace YARG.Serialization {
 			} catch (Exception e) {
 				Debug.LogError($"Failed to parse song.ini for `{song.RootFolder}`.");
 				Debug.LogException(e);
+				throw e;
 			}
 		}
 

--- a/Assets/Script/SongLibrary.cs
+++ b/Assets/Script/SongLibrary.cs
@@ -243,7 +243,15 @@ namespace YARG {
 
 					// Create a SongInfo
 					var songInfo = new SongInfo(midPath, info.root, info.type);
-					SongIni.CompleteSongInfo(songInfo);
+					try
+					{
+						SongIni.CompleteSongInfo(songInfo);
+					}
+					catch (Exception e)
+					{
+						// Something went wrong with the parsing, skip this song
+						continue;
+					}		
 
 					// Add it to the list of songs
 					songsTemp.Add(songInfo);

--- a/Assets/Script/SongLibrary.cs
+++ b/Assets/Script/SongLibrary.cs
@@ -250,6 +250,8 @@ namespace YARG {
 					catch (Exception e)
 					{
 						// Something went wrong with the parsing, skip this song
+						Debug.LogError($"Failed to parse song.ini for `{info.path}`.");
+						Debug.LogException(e);
 						continue;
 					}		
 


### PR DESCRIPTION
Previous implementation of filling the song list did skip songs without notes.mid files but whilst it did log errors about failure to parse song.ini files, it still added said broken songs to the songlist, rendering the search function unusable.

When a parsing error occurs, an exception is thrown and caught by the code that fills up the songlist and the song is skipped.

I also changed the behaviour when the "song" section isn't found in song.ini, because the song would show up as a blank entry in the songlist and break the search function too.