### PR TITLE
Bugfix: Cymbal_Glow Material not applying correctly

### DIFF
--- a/Assets/Art/Materials/PlayMode/Cymbal_Glow.mat
+++ b/Assets/Art/Materials/PlayMode/Cymbal_Glow.mat
@@ -35,7 +35,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BaseMap:
-        m_Texture: {fileID: 2800000, guid: da466a9517728fa469bcb5f873b398c5, type: 3}
+        m_Texture: {fileID: 2800000, guid: 3a08841e37830f044ba28e9973664b63, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:
@@ -59,7 +59,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 3a08841e37830f044ba28e9973664b63, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
@@ -109,12 +109,12 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Metallic: 0
+    - _Metallic: 0.777
     - _OcclusionStrength: 1
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Smoothness: 0.512
+    - _Smoothness: 0.778
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1


### PR DESCRIPTION
Fixed a bug where cymbal materials on their base weren't being displayed correctly.