### PR TITLE
More input strategy refactors/fixes

### DIFF
--- a/Assets/Script/GameManager.cs
+++ b/Assets/Script/GameManager.cs
@@ -71,6 +71,12 @@ namespace YARG {
 			LoadScene(SceneIndex.MENU);
 		}
 
+		private void OnDestroy() {
+			foreach (var player in PlayerManager.players) {
+				player.inputStrategy.Disable();
+			}
+		}
+
 		private void Update() {
 			OnUpdate?.Invoke();
 		}

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -179,11 +179,12 @@ namespace YARG.Input {
 		}
 
 		/// <summary>
-		/// Forces the input strategy to update its inputs.
+		/// Forces the input strategy to update.
 		/// </summary>
-		public void ForceUpdateInputs() {
+		public void ForceUpdate() {
 			UpdateNavigationMode();
 			UpdatePlayerMode();
+			OnUpdate();
 		}
 
 		public static bool IsControlPressed(InputControl<float> control) {

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -71,6 +71,10 @@ namespace YARG.Input {
 		}
 
 		public void Enable() {
+			if (Enabled) {
+				return;
+			}
+
 			// Bind events
 			InputSystem.onAfterUpdate += OnUpdate;
 			if (_inputDevice != null) {
@@ -81,6 +85,10 @@ namespace YARG.Input {
 		}
 
 		public void Disable() {
+			if (!Enabled) {
+				return;
+			}
+
 			// Unbind events
 			InputSystem.onAfterUpdate -= OnUpdate;
 			eventListener?.Dispose();

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -156,7 +156,7 @@ namespace YARG.Input {
 			}
 		}
 
-		private void OnUpdate() {
+		protected virtual void OnUpdate() {
 			if (botMode) {
 				UpdateBotMode();
 			}
@@ -179,7 +179,7 @@ namespace YARG.Input {
 		}
 
 		/// <summary>
-		/// Forces the input strategy to update its inputs. This is used for microphone input.
+		/// Forces the input strategy to update its inputs.
 		/// </summary>
 		public void ForceUpdateInputs() {
 			UpdateNavigationMode();

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -72,7 +72,7 @@ namespace YARG.Input {
 
 		public void Enable() {
 			// Bind events
-			GameManager.OnUpdate += OnUpdate;
+			InputSystem.onAfterUpdate += OnUpdate;
 			if (_inputDevice != null) {
 				eventListener = InputSystem.onEvent.ForDevice(_inputDevice).Call(OnInputEvent);
 			}
@@ -82,7 +82,7 @@ namespace YARG.Input {
 
 		public void Disable() {
 			// Unbind events
-			GameManager.OnUpdate -= OnUpdate;
+			InputSystem.onAfterUpdate -= OnUpdate;
 			eventListener?.Dispose();
 			eventListener = null;
 

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -58,6 +58,11 @@ namespace YARG.Input {
 				return;
 			}
 
+			// Not in a song yet
+			if (MicPlayer.Instance == null) {
+				return;
+			}
+
 			var audioSource = MicPlayer.Instance.dummyAudioSources[this];
 
 			// Get and optimize samples

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -48,6 +48,11 @@ namespace YARG.Input {
 			SAMPLE_SCAN_SIZE = (int) (TARGET_SIZE * (float) AudioSettings.outputSampleRate / TARGET_SIZE_REF);
 		}
 
+		protected override void OnUpdate() {
+			base.OnUpdate();
+			UpdatePlayerMode();
+		}
+
 		protected override void UpdatePlayerMode() {
 			if (microphoneIndex == INVALID_MIC_INDEX) {
 				return;

--- a/Assets/Script/Input/RealGuitarInputStrategy.cs
+++ b/Assets/Script/Input/RealGuitarInputStrategy.cs
@@ -37,6 +37,23 @@ namespace YARG.Input {
 		private float? stringGroupingTimer = null;
 		private StrumFlag stringGroupingFlag = StrumFlag.NONE;
 
+		protected override void OnUpdate() {
+			base.OnUpdate();
+
+			// Group up strums
+			if (stringGroupingTimer != null) {
+				stringGroupingTimer -= Time.deltaTime;
+
+				if (stringGroupingTimer <= 0f) {
+					StrumEvent?.Invoke(stringGroupingFlag);
+					stringGroupingFlag = StrumFlag.NONE;
+					stringGroupingTimer = null;
+
+					CallGenericCalbirationEvent();
+				}
+			}
+		}
+
 		protected override void UpdatePlayerMode() {
 			if (InputDevice is not ProGuitar input) {
 				return;
@@ -60,19 +77,6 @@ namespace YARG.Input {
 
 					// Start grouping if not already
 					stringGroupingTimer ??= 0.05f;
-				}
-			}
-
-			// Group up strums
-			if (stringGroupingTimer != null) {
-				stringGroupingTimer -= Time.deltaTime;
-
-				if (stringGroupingTimer <= 0f) {
-					StrumEvent?.Invoke(stringGroupingFlag);
-					stringGroupingFlag = StrumFlag.NONE;
-					stringGroupingTimer = null;
-
-					CallGenericCalbirationEvent();
 				}
 			}
 

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -462,9 +462,6 @@ namespace YARG.PlayMode {
 				var player = playerInfo.player;
 				var micInput = (MicInputStrategy) player.inputStrategy;
 
-				// Update mic input
-				micInput.ForceUpdateInputs();
-
 				// Get the correct range
 				float correctRange = player.chosenDifficulty switch {
 					Difficulty.EASY => 4f,

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -284,6 +284,10 @@ namespace YARG.PlayMode {
 		}
 
 		private void OnDestroy() {
+			if (Instance == this) {
+				Instance = null;
+			}
+
 			if (!hasMic) {
 				return;
 			}


### PR DESCRIPTION
Summary:

- Use `InputSystem.onAfterUpdate` for updating input strategies, to ensure things are updated before the rest of the game is
- Make input strategy OnUpdate method virtual so other strategy types can still do per-update logic instead of just per-event updates
  - Used for vocals and Pro Guitar
- Fix Pro Guitar strategy's strum grouping timer being updated in input event updates instead of persistent updates
- Fix input strategies continuing to update after exiting play mode in the editor