### PR TITLE
Turn null artist information in songs.dta into Unknown Artist

### DIFF
--- a/Assets/Script/Serialization/Xbox/XboxSong.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSong.cs
@@ -88,7 +88,11 @@ namespace YARG.Serialization {
 			// song.delay
 			song.drumType = rb ? SongInfo.DrumType.FOUR_LANE : SongInfo.DrumType.FIVE_LANE;
 			// song.hopoFreq
-			song.artistName = songDta.artist;
+			if (songDta.artist != null){
+				song.artistName = songDta.artist;
+			}else {
+				song.artistName = "Unknown Artist";
+			}
 			song.album = songDta.albumName;
 			song.genre = songDta.genre;
 			// song.charter

--- a/Assets/Script/Serialization/Xbox/XboxSong.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSong.cs
@@ -88,11 +88,7 @@ namespace YARG.Serialization {
 			// song.delay
 			song.drumType = rb ? SongInfo.DrumType.FOUR_LANE : SongInfo.DrumType.FIVE_LANE;
 			// song.hopoFreq
-			if (songDta.artist != null){
-				song.artistName = songDta.artist;
-			}else {
-				song.artistName = "Unknown Artist";
-			}
+			song.artistName = songDta.artist !=null ? songDta.artist : "Unknown Artist";
 			song.album = songDta.albumName;
 			song.genre = songDta.genre;
 			// song.charter

--- a/Assets/Script/Serialization/Xbox/XboxSong.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSong.cs
@@ -88,7 +88,7 @@ namespace YARG.Serialization {
 			// song.delay
 			song.drumType = rb ? SongInfo.DrumType.FOUR_LANE : SongInfo.DrumType.FIVE_LANE;
 			// song.hopoFreq
-			song.artistName = songDta.artist !=null ? songDta.artist : "Unknown Artist";
+			song.artistName = songDta.artist != null ? songDta.artist : "Unknown Artist";
 			song.album = songDta.albumName;
 			song.genre = songDta.genre;
 			// song.charter


### PR DESCRIPTION
This fixes searching by artist being broken when a RB CON doesn't have artist information in its songs.dta file.