### PR TITLE
Add missing navigation controls for drums and vocals

### DIFF
--- a/Assets/Script/Input/DrumsInputStrategy.cs
+++ b/Assets/Script/Input/DrumsInputStrategy.cs
@@ -17,6 +17,10 @@ namespace YARG.Input {
 		public const string KICK = "kick";
 		public const string KICK_ALT = "kick_alt";
 
+		public const string PAUSE = "pause";
+		public const string UP = "up";
+		public const string DOWN = "down";
+
 		private List<NoteInfo> botChart;
 
 		public delegate void DrumHitAction(int drum, bool cymbal);
@@ -25,8 +29,8 @@ namespace YARG.Input {
 
 		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
 			{ RED_PAD,       new(BindingType.BUTTON, "Red Pad", RED_PAD) },
-			{ YELLOW_PAD,    new(BindingType.BUTTON, "Yellow Pad", YELLOW_PAD) },
-			{ BLUE_PAD,      new(BindingType.BUTTON, "Blue Pad", BLUE_PAD) },
+			{ YELLOW_PAD,    new(BindingType.BUTTON, "Yellow Pad (Menu Up)", YELLOW_PAD) },
+			{ BLUE_PAD,      new(BindingType.BUTTON, "Blue Pad (Menu Down)", BLUE_PAD) },
 			{ GREEN_PAD,     new(BindingType.BUTTON, "Green Pad", GREEN_PAD) },
 
 			{ YELLOW_CYMBAL, new(BindingType.BUTTON, "Yellow Cymbal", YELLOW_CYMBAL) },
@@ -34,7 +38,11 @@ namespace YARG.Input {
 			{ GREEN_CYMBAL,  new(BindingType.BUTTON, "Green Cymbal", GREEN_CYMBAL) },
 
 			{ KICK,          new(BindingType.BUTTON, "Kick", KICK) },
-			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) }
+			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) },
+
+			{ PAUSE,         new(BindingType.BUTTON, "Pause", PAUSE) },
+			{ UP,            new(BindingType.BUTTON, "Navigate Up", UP) },
+			{ DOWN,          new(BindingType.BUTTON, "Navigate Down", DOWN) },
 		};
 
 		protected override void UpdatePlayerMode() {
@@ -118,8 +126,16 @@ namespace YARG.Input {
 		protected override void UpdateNavigationMode() {
 			CallGenericNavigationEventForButton(YELLOW_PAD, NavigationType.UP);
 			CallGenericNavigationEventForButton(BLUE_PAD, NavigationType.DOWN);
+			CallGenericNavigationEventForButton(UP, NavigationType.UP);
+			CallGenericNavigationEventForButton(DOWN, NavigationType.DOWN);
+
 			CallGenericNavigationEventForButton(GREEN_PAD, NavigationType.PRIMARY);
 			CallGenericNavigationEventForButton(RED_PAD, NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton(YELLOW_CYMBAL, NavigationType.TERTIARY);
+
+			if (WasMappingPressed(PAUSE)) {
+				CallPauseEvent();
+			}
 		}
 
 		public override string[] GetAllowedInstruments() {

--- a/Assets/Script/Input/GHDrumsInputStrategy.cs
+++ b/Assets/Script/Input/GHDrumsInputStrategy.cs
@@ -14,6 +14,10 @@ namespace YARG.Input {
 		public const string KICK = "kick";
 		public const string KICK_ALT = "kick_alt";
 
+		public const string PAUSE = "pause";
+		public const string UP = "up";
+		public const string DOWN = "down";
+
 		private List<NoteInfo> botChart;
 
 		public delegate void DrumHitAction(int drum);
@@ -28,7 +32,11 @@ namespace YARG.Input {
 			{ GREEN_PAD,     new(BindingType.BUTTON, "Green Pad", GREEN_PAD) },
 
 			{ KICK,          new(BindingType.BUTTON, "Kick", KICK) },
-			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) }
+			{ KICK_ALT,      new(BindingType.BUTTON, "Kick Alt", KICK_ALT) },
+
+			{ PAUSE,         new(BindingType.BUTTON, "Pause", PAUSE) },
+			{ UP,            new(BindingType.BUTTON, "Navigate Up", UP) },
+			{ DOWN,          new(BindingType.BUTTON, "Navigate Down", DOWN) },
 		};
 
 		protected override void UpdatePlayerMode() {
@@ -101,7 +109,16 @@ namespace YARG.Input {
 		}
 
 		protected override void UpdateNavigationMode() {
-			// TODO
+			CallGenericNavigationEventForButton(GREEN_PAD, NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton(RED_PAD, NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton(YELLOW_CYMBAL, NavigationType.TERTIARY);
+
+			CallGenericNavigationEventForButton(UP, NavigationType.UP);
+			CallGenericNavigationEventForButton(DOWN, NavigationType.DOWN);
+
+			if (WasMappingPressed(PAUSE)) {
+				CallPauseEvent();
+			}
 		}
 
 		public override string[] GetAllowedInstruments() {

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -7,6 +7,14 @@ using YARG.PlayMode;
 
 namespace YARG.Input {
 	public sealed class MicInputStrategy : InputStrategy {
+		public const string CONFIRM = "confirm";
+		public const string BACK = "back";
+		public const string MENU_ACTION = "menu_action";
+
+		public const string PAUSE = "pause";
+		public const string UP = "up";
+		public const string DOWN = "down";
+
 		private static readonly int SAMPLE_SCAN_SIZE;
 
 		private const float UPDATE_TIME = 1f / 20f;
@@ -47,6 +55,16 @@ namespace YARG.Input {
 			// Set the scan size relative to the sample rate
 			SAMPLE_SCAN_SIZE = (int) (TARGET_SIZE * (float) AudioSettings.outputSampleRate / TARGET_SIZE_REF);
 		}
+
+		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
+			{ CONFIRM,       new(BindingType.BUTTON, "Confirm/Select (Green)", CONFIRM) },
+			{ BACK,          new(BindingType.BUTTON, "Back (Red)", BACK) },
+			{ MENU_ACTION,     new(BindingType.BUTTON, "Menu Action (Yellow)", MENU_ACTION) },
+
+			{ PAUSE,         new(BindingType.BUTTON, "Pause", PAUSE) },
+			{ UP,            new(BindingType.BUTTON, "Navigate Up", UP) },
+			{ DOWN,          new(BindingType.BUTTON, "Navigate Down", DOWN) },
+		};
 
 		protected override void OnUpdate() {
 			base.OnUpdate();
@@ -257,7 +275,16 @@ namespace YARG.Input {
 		}
 
 		protected override void UpdateNavigationMode() {
-			// TODO
+			CallGenericNavigationEventForButton(CONFIRM, NavigationType.PRIMARY);
+			CallGenericNavigationEventForButton(BACK, NavigationType.SECONDARY);
+			CallGenericNavigationEventForButton(MENU_ACTION, NavigationType.TERTIARY);
+
+			CallGenericNavigationEventForButton(UP, NavigationType.UP);
+			CallGenericNavigationEventForButton(DOWN, NavigationType.DOWN);
+
+			if (WasMappingPressed(PAUSE)) {
+				CallPauseEvent();
+			}
 		}
 
 		public override string[] GetAllowedInstruments() {


### PR DESCRIPTION
Drums:

![image](https://user-images.githubusercontent.com/29052821/235112429-574f9ac4-36c1-45d5-ba09-b584dbc24047.png)

Vocals:

![image](https://user-images.githubusercontent.com/29052821/235112450-400af792-ed05-4a42-b786-2f04f0f2980e.png)

Pro Guitar navigation will come later, as I'd like to try and unify its input processing with everything else if possible.