### PR TITLE
Fix CONs breaking when selecting restart when paused

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -200,6 +200,9 @@ namespace YARG {
 		}
 		
 		public void LoadMogg(XboxMoggData moggData, bool isSpeedUp) {
+			Debug.Log("Loading mogg song");
+			UnloadSong();
+			
 			int moggOffset = moggData.MoggAddressAudioOffset;
 			long moggLength = moggData.MoggAudioLength;
 			
@@ -236,6 +239,7 @@ namespace YARG {
 
 			// Free mixer (and all channels in it)
 			_mixer?.Dispose();
+			_mixer = null;
 		}
 
 		public void Play() {
@@ -273,7 +277,7 @@ namespace YARG {
 		}
 
 		public void SetStemVolume(SongStem stem, double volume) {
-			var channel = _mixer.GetChannel(stem);
+			var channel = _mixer?.GetChannel(stem);
 
 			channel?.SetVolume(volume);
 		}

--- a/Assets/Script/UI/PauseMenu.cs
+++ b/Assets/Script/UI/PauseMenu.cs
@@ -139,6 +139,7 @@ namespace YARG.UI {
 		}
 
 		private void OnRestartSelected() {
+			GameManager.AudioManager.UnloadSong();
 			GameManager.Instance.LoadScene(SceneIndex.PLAY);
 			Play.Instance.Paused = false;
 		}


### PR DESCRIPTION
Songs in CON format (that use MOGGs) would break when selecting restart as the mogg wouldn't be unloaded across scene transition. That is now fixed