### PR TITLE
Move ScoreDisplay when MicPlayer isn't present

### DIFF
--- a/Assets/Script/PlayMode/ScoreDisplay.cs
+++ b/Assets/Script/PlayMode/ScoreDisplay.cs
@@ -1,23 +1,41 @@
+using System.Collections;
 using TMPro;
 using UnityEngine;
 
-public class ScoreDisplay : MonoBehaviour {
-	[SerializeField]
-	private TextMeshProUGUI scoreText;
+namespace YARG.PlayMode {
+	public class ScoreDisplay : MonoBehaviour {
+		[SerializeField]
+		private TextMeshProUGUI scoreText;
 
-	private void Start() {
-		scoreText.text = $"<mspace=0.59em>0";
-	}
+		private void Start() {
+			scoreText.text = $"<mspace=0.59em>0";
+			StartCoroutine(LateStart());
+		}
 
-	private void OnEnable() {
-		ScoreKeeper.OnScoreChange += OnScoreChange;
-	}
+		private IEnumerator LateStart() {
+			// wait for MicPlayer.Start to run
+			yield return new WaitForEndOfFrame();
+			
+			// Move score display if MicPlayer is not present
+			if (!MicPlayer.Instance) {
+				var rt = this.GetComponent<RectTransform>();
+				var pos = rt.anchoredPosition;
+				Debug.Log(pos);
+				pos.y = -93;
+				rt.anchoredPosition = pos;
+			}
+		}
 
-	private void OnDisable() {
-		ScoreKeeper.OnScoreChange -= OnScoreChange;
-	}
+		private void OnEnable() {
+			ScoreKeeper.OnScoreChange += OnScoreChange;
+		}
 
-	private void OnScoreChange() {
-		scoreText.text = $"<mspace=0.59em>{ScoreKeeper.TotalScore:n0}";
+		private void OnDisable() {
+			ScoreKeeper.OnScoreChange -= OnScoreChange;
+		}
+
+		private void OnScoreChange() {
+			scoreText.text = $"<mspace=0.59em>{ScoreKeeper.TotalScore:n0}";
+		}
 	}
 }

--- a/Assets/Script/PlayMode/ScoreKeeper.cs
+++ b/Assets/Script/PlayMode/ScoreKeeper.cs
@@ -1,67 +1,69 @@
 using System.Collections.Generic;
 using Unity.Mathematics;
 
-// Score keeping for each track
-public class ScoreKeeper {
-	public delegate void ScoreAction();
-	/// <summary>
-	/// Fires when points have been added to an instance's score.
-	/// </summary>
-	public static event ScoreAction OnScoreChange;
+namespace YARG.PlayMode {
+	// Score keeping for each track with an instance
+	public class ScoreKeeper {
+		public delegate void ScoreAction();
+		/// <summary>
+		/// Fires when points have been added to an instance's score.
+		/// </summary>
+		public static event ScoreAction OnScoreChange;
 
-	// keep track of all instances to calculate the band total
-	public static List<ScoreKeeper> instances = new();
-	public static double TotalScore {
-		get {
-			double sum = 0;
-			foreach (var ins in instances) {
-				sum += ins.Score;
+		// keep track of all instances to calculate the band total
+		public static List<ScoreKeeper> instances = new();
+		public static double TotalScore {
+			get {
+				double sum = 0;
+				foreach (var ins in instances) {
+					sum += ins.Score;
+				}
+				return sum;
 			}
-			return sum;
 		}
-	}
 
-	public static void Reset() {
-		instances.Clear();
-	}
+		public static void Reset() {
+			instances.Clear();
+		}
 
-	public double Score { get; private set; } = 0;
+		public double Score { get; private set; } = 0;
 
-	/// <summary>
-	/// Add points for this keeper. Fires the OnScoreChange event.
-	/// </summary>
-	/// <param name="points"></param>
-	public void Add(double points) {
-		Score += points;
-		OnScoreChange?.Invoke();
-	}
+		/// <summary>
+		/// Add points for this keeper. Fires the OnScoreChange event.
+		/// </summary>
+		/// <param name="points"></param>
+		public void Add(double points) {
+			Score += points;
+			OnScoreChange?.Invoke();
+		}
 
-	/// <summary>
-	/// Calculate and store bonus points earned from a solo section.
-	/// </summary>
-	/// <param name="notesHit"></param>
-	/// <param name="notesMax"></param>
-	/// <returns>The bonus points earned.</returns>
-	public double AddSolo(int notesHit, int notesMax) {
-		double ratio = (double) notesHit / notesMax;
+		/// <summary>
+		/// Calculate and store bonus points earned from a solo section.
+		/// </summary>
+		/// <param name="notesHit"></param>
+		/// <param name="notesMax"></param>
+		/// <returns>The bonus points earned.</returns>
+		public double AddSolo(int notesHit, int notesMax) {
+			double ratio = (double) notesHit / notesMax;
 
-		if (ratio <= 0.5)
-			return 0;
+			if (ratio <= 0.5)
+				return 0;
 
-		// linear
-		double multiplier = math.clamp((ratio - 0.5) / 0.5, 0, 1);
-		double ptsEarned = 100 * notesHit * multiplier;
+			// linear
+			double multiplier = math.clamp((ratio - 0.5) / 0.5, 0, 1);
+			double ptsEarned = 100 * notesHit * multiplier;
 
-		// +5% bonus points
-		// TODO: limit to FC? decide to keep at all?
-		if (ratio >= 1)
-			ptsEarned = 1.05 * ptsEarned;
+			// +5% bonus points
+			// TODO: limit to FC? decide to keep at all?
+			if (ratio >= 1)
+				ptsEarned = 1.05 * ptsEarned;
 
-		Add(ptsEarned);
-		return ptsEarned;
-	}
+			Add(ptsEarned);
+			return ptsEarned;
+		}
 
-	public ScoreKeeper() {
-		instances.Add(this);
+		public ScoreKeeper() {
+			instances.Add(this);
+		}
 	}
 }

--- a/Assets/Script/PlayMode/StarDisplay.cs
+++ b/Assets/Script/PlayMode/StarDisplay.cs
@@ -43,7 +43,9 @@ namespace YARG.PlayMode {
 		}
 
 		private void OnScoreChange() {
-			SetStars(StarScoreKeeper.BandStars);
+			// don't do anything if gold stars have been achieved
+			if (!goldAchieved)
+				SetStars(StarScoreKeeper.BandStars);
 		}
 
 		private void SetStarProgress(GameObject star, double progress) {
@@ -67,8 +69,6 @@ namespace YARG.PlayMode {
 		/// </summary>
 		/// <param name="stars"></param>
 		public void SetStars(double stars) {
-			if (goldAchieved) { return; }
-
 			int topStar = (int) stars;
 
 			double curProgress = stars - (int) stars;
@@ -105,12 +105,13 @@ namespace YARG.PlayMode {
 				objGoldMeterMaster.SetActive(false);
 
 				GameManager.AudioManager.PlaySoundEffect(SfxSample.StarGold);
-
 				goldAchieved = true; // so we stop trying to update
 			}
 		}
 
 		private void Update() {
+			if (goldAchieved) { return; }
+			
 			int nextBar = curBar;
 			while (nextBar < bars.Count - 1 && bars[nextBar] <= Play.Instance.SongTime) {
 				nextBar++;


### PR DESCRIPTION
Simple UI logic: if MicPlayer.Instance is null, move ScoreDisplay up. Otherwise stay.

As an aside, moved ScoreKeeper into the PlayMode namespace.