### PR TITLE
Minor five-fret engine tweaks

### DIFF
--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -4,11 +4,18 @@ namespace YARG {
 	public static class Constants {
 		public static readonly YargVersion VERSION_TAG = YargVersion.Parse("v0.10.0b");
 
+		// General
 		public const float HIT_MARGIN = 0.095f;
+		// Guitar
 		public const float STRUM_LENIENCY = 0.065f;
 		public const bool ANCHORING = true;
 		public const bool INFINITE_FRONTEND = false;
 		public const bool ANCHOR_CHORD_HOPO = true;
+		public const bool EASY_TAP_RECOVERY = true;
+		// Guitar - Anti-ghosting
 		public const int EXTRA_ALLOWED_GHOSTS = 0;
+		public const bool ALLOW_DESC_GHOSTS = true;
+		public const bool ALLOW_GHOST_IF_NO_NOTES = true; // seems to allow more ghosting than it should...
+		public const float ALLOW_GHOST_IF_NO_NOTES_THRESHOLD = 1.5f;
 	}
 }


### PR DESCRIPTION
- ALLOW_DESC_GHOSTS
  - Already implemented, just made into a toggle.
- ALLOW_GHOST_IF_NO_NOTES
  - If the next note is outside of the timing window, do not check for ghost inputs;
  - For some reason, in some rare scenarios it seems to allow ghosting when it shouldn't;
  - Increasing the ALLOW_GHOST_IF_NO_NOTES_THRESHOLD variable might alleviate that;
  - However if set too large, it might nullify the effect of the toggle.
- EASY_TAP_RECOVERY
  - If tapping to recover combo during tap note section, skip to first valid note within the timing window. This will make it easier to recover;
  - Only applies if combo is 0, and all following notes are tap notes, so it won't negatively impact FC runs.