### PR TITLE
Overhaul Star Power FX

### DIFF
--- a/Assets/Script/Audio/AudioHelpers.cs
+++ b/Assets/Script/Audio/AudioHelpers.cs
@@ -34,16 +34,16 @@ namespace YARG {
 
 		public static readonly IList<double> SfxVolume = new[] {
 			0.5,
-			0.4,
+			0.45,
 			0.5,
-			0.4,
+			0.45,
 			0.5,
-			0.12,
+			0.15,
 			1.0,
 			1.0,
 		};
 
-		public static IEnumerable<string> GetSupportedStems(string folder) {
+		public static ICollection<string> GetSupportedStems(string folder) {
 			var stems = new List<string>();
 
 			foreach (string filePath in Directory.GetFiles(folder)) {

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using ManagedBass;
 using UnityEngine;
@@ -156,7 +155,7 @@ namespace YARG {
 			Debug.Log("Finished loading SFX");
 		}
 
-		public void LoadSong(IEnumerable<string> stems, bool isSpeedUp) {
+		public void LoadSong(ICollection<string> stems, bool isSpeedUp) {
 			Debug.Log("Loading song");
 			UnloadSong();
 
@@ -171,6 +170,11 @@ namespace YARG {
 
 				// Gets the index (SongStem to int) from the name
 				var songStem = AudioHelpers.GetStemFromName(stemName);
+				
+				// Assign 1 stem songs to the song stem
+				if (stems.Count == 1) {
+					songStem = SongStem.Song;
+				}
 
 				var stemChannel = new BassStemChannel(this, stemPath, songStem);
 				if (stemChannel.Load(isSpeedUp, PlayMode.Play.speed) != 0) {

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using ManagedBass;
+using ManagedBass.DirectX8;
+using ManagedBass.Fx;
+
+namespace YARG {
+	public static class BassHelpers {
+		
+		public const EffectType REVERB_TYPE = EffectType.Freeverb;
+		
+		public static readonly PeakEQParameters LowEqParams = new() {
+			fBandwidth = 1.25f,
+			fCenter = 250.0f,
+			fGain = -12f
+		};
+		
+		public static readonly PeakEQParameters MidEqParams = new() {
+			fBandwidth = 1.25f,
+			fCenter = 2300.0f,
+			fGain = 2.25f
+		};
+		
+		public static readonly PeakEQParameters HighEqParams = new() {
+			fBandwidth = 0.75f,
+			fCenter = 6000.0f,
+			fGain = 2f
+		};
+		
+		public static int AddReverbToChannel(int handle) {
+			// Set reverb FX
+			int reverbFxHandle = Bass.ChannelSetFX(handle, REVERB_TYPE, 0);
+			if (reverbFxHandle == 0) {
+				return 0;
+			}
+
+			IEffectParameter reverbParams = REVERB_TYPE switch {
+				EffectType.DXReverb => new DXReverbParameters {
+					fInGain = -5f, fReverbMix = 0f, fReverbTime = 1000.0f, fHighFreqRTRatio = 0.001f
+				},
+				EffectType.Freeverb => new ReverbParameters() {
+					fDryMix = 0.5f,
+					fWetMix = 1.5f,
+					fRoomSize = 0.75f,
+					fDamp = 0.5f,
+					fWidth = 1.0f,
+					lMode = 0
+				},
+				_ => throw new ArgumentOutOfRangeException()
+			};
+
+			return !Bass.FXSetParameters(reverbFxHandle, reverbParams) ? 0 : reverbFxHandle;
+		}
+		
+		public static int AddEqToChannel(int handle, IEffectParameter eqParams) {
+			int eqHandle = Bass.ChannelSetFX(handle, EffectType.PeakEQ, 0);
+			if (eqHandle == 0) {
+				return 0;
+			}
+			
+			return !Bass.FXSetParameters(eqHandle, eqParams) ? 0 : eqHandle;
+		}
+		
+		public static double GetChannelLengthInSeconds(int channel) {
+			long length = Bass.ChannelGetLength(channel);
+
+			if (length == -1) {
+				return (double) Bass.LastError;
+			}
+
+			double seconds = Bass.ChannelBytes2Seconds(channel, length);
+
+			if (seconds < 0) {
+				return (double) Bass.LastError;
+			}
+
+			return seconds;
+		}
+		
+	}
+}

--- a/Assets/Script/Audio/Bass/BassHelpers.cs.meta
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dd9f3bdc284e44f6abe30ba11ecdfa4c
+timeCreated: 1682791107

--- a/Assets/Script/Audio/Bass/BassMoggStem.cs
+++ b/Assets/Script/Audio/Bass/BassMoggStem.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ManagedBass;
-using ManagedBass.DirectX8;
 using ManagedBass.Fx;
+using ManagedBass.Mix;
 using UnityEngine;
 
 namespace YARG {
@@ -15,6 +15,7 @@ namespace YARG {
 		public double Volume { get; private set; }
 		
 		public int[] BassChannels { get; }
+		public int[] ReverbChannels { get; }
 		public int[] ChannelIndexes { get; }
 		
 		private readonly IAudioManager _manager;
@@ -22,7 +23,6 @@ namespace YARG {
 		private readonly int[] _splitStreams;
 
 		private readonly Dictionary<int, Dictionary<EffectType, int>> _effects;
-		private readonly Dictionary<int, Dictionary<DSPType, int>> _dspHandles;
 
 		private readonly DSPProcedure _dspGain;
 
@@ -30,6 +30,7 @@ namespace YARG {
 		
 		private double _lastStemVolume;
 
+		private bool _isReverbing;
 		private bool _isLoaded;
 		private bool _disposed;
 
@@ -39,15 +40,13 @@ namespace YARG {
 
 			_splitStreams = splitStreams;
 			BassChannels = new int[splitStreams.Length];
+			ReverbChannels = new int[splitStreams.Length];
 			ChannelIndexes = new int[splitStreams.Length];
 			
 			Volume = 1;
 			
 			_lastStemVolume = _manager.GetVolumeSetting(Stem);
 			_effects = new Dictionary<int, Dictionary<EffectType, int>>();
-			_dspHandles = new Dictionary<int, Dictionary<DSPType, int>>();
-
-			_dspGain += BassStemChannel.GainDSP;
 		}
 		
 		~BassMoggStem() {
@@ -65,34 +64,55 @@ namespace YARG {
 			const BassFlags flags = BassFlags.SampleOverrideLowestVolume | BassFlags.Decode | BassFlags.FxFreeSource;
 			
 			for (var i = 0; i < _splitStreams.Length; i++) {
-				BassChannels[i] = BassFx.TempoCreate(_splitStreams[i], flags);
-				int bassChannel = BassChannels[i];
+				int main = BassMix.CreateSplitStream(_splitStreams[i], BassFlags.Decode | BassFlags.SplitPosition, null);
+				int reverbSplit = BassMix.CreateSplitStream(_splitStreams[i], BassFlags.Decode | BassFlags.SplitPosition, null);
 				
-				Bass.ChannelSetAttribute(bassChannel, ChannelAttribute.Volume, _manager.GetVolumeSetting(Stem));
+				BassChannels[i] = BassFx.TempoCreate(main, flags);
+				ReverbChannels[i] = BassFx.TempoCreate(reverbSplit, flags);
+				
+				// Apply a compressor to balance stem volume
+				Bass.ChannelSetFX(BassChannels[i], EffectType.Compressor, 1);
+				Bass.ChannelSetFX(ReverbChannels[i], EffectType.Compressor, 1);
+
+				var compressorParams = new CompressorParameters {
+					fGain = -3,
+					fThreshold = -2,
+					fAttack = 0.01f,
+					fRelease = 0.1f,
+					fRatio = 4,
+				};
+
+				Bass.FXSetParameters(BassChannels[i], compressorParams);
+				Bass.FXSetParameters(ReverbChannels[i], compressorParams);
+				
+				Bass.ChannelSetAttribute(BassChannels[i], ChannelAttribute.Volume, _manager.GetVolumeSetting(Stem));
+				Bass.ChannelSetAttribute(ReverbChannels[i], ChannelAttribute.Volume, 0);
 
 				if (isSpeedUp) {
 					// Gets relative speed from 100% (so 1.05f = 5% increase)
 					float relativeSpeed = Math.Abs(speed) * 100;
 					relativeSpeed -= 100;
-					Bass.ChannelSetAttribute(bassChannel, ChannelAttribute.Tempo, relativeSpeed);
+					Bass.ChannelSetAttribute(BassChannels[i], ChannelAttribute.Tempo, relativeSpeed);
+					Bass.ChannelSetAttribute(ReverbChannels[i], ChannelAttribute.Tempo, relativeSpeed);
 
 					// Have to handle pitch separately for some reason
 					if (_manager.IsChipmunkSpeedup) {
 						// Calculates semitone increase, can probably be improved but this will do for now
 						float semitones = relativeSpeed > 0 ? 1 * speed : -1 * speed;
-						Bass.ChannelSetAttribute(bassChannel, ChannelAttribute.Pitch, semitones);
+						Bass.ChannelSetAttribute(BassChannels[i], ChannelAttribute.Pitch, semitones);
+						Bass.ChannelSetAttribute(ReverbChannels[i], ChannelAttribute.Pitch, semitones);
 					}
 				}
 
 				// Get longest channel as part of this stem
-				double length = GetChannelLengthInSeconds(BassChannels[i]);
+				double length = BassHelpers.GetChannelLengthInSeconds(BassChannels[i]);
 				if(length > LengthD) {
-					_leadChannel = bassChannel;
+					_leadChannel = BassChannels[i];
 					LengthD = length;
 				}
 				
 				_effects.Add(BassChannels[i], new Dictionary<EffectType, int>());
-				_dspHandles.Add(BassChannels[i], new Dictionary<DSPType, int>());
+				_effects.Add(ReverbChannels[i], new Dictionary<EffectType, int>());
 			}
 
 			_isLoaded = true;
@@ -121,34 +141,61 @@ namespace YARG {
 			foreach (int channel in BassChannels) {
 				Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, newBassVol);
 			}
+
+			foreach(int channel in ReverbChannels) {
+				if (_isReverbing) {
+					Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, newBassVol * 0.7);
+				} else {
+					Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, 0);
+				}
+			}
 		}
 
 		public void SetReverb(bool reverb) {
+			_isReverbing = reverb;
 			if (reverb) {
 				// Set reverb FX
-				foreach (int channel in BassChannels) {
+				foreach (int channel in ReverbChannels) {
 					// Reverb already applied
 					if (_effects[channel].ContainsKey(REVERB_TYPE))
 						return;
+
+					int lowEqHandle = BassHelpers.AddEqToChannel(channel, BassHelpers.LowEqParams);
+					int midEqHandle = BassHelpers.AddEqToChannel(channel, BassHelpers.MidEqParams);
+					int highEqHandle = BassHelpers.AddEqToChannel(channel, BassHelpers.HighEqParams);
+					int reverbHandle = BassHelpers.AddReverbToChannel(channel);
 					
-					int reverbHandle = AddReverbToChannel(channel);
-					int gainDspHandle = Bass.ChannelSetDSP(channel, _dspGain);
+					double volumeSetting = _manager.GetVolumeSetting(Stem);
+					Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume,volumeSetting * Volume * 0.7);
 					
 					_effects[channel].Add(REVERB_TYPE, reverbHandle);
-					_dspHandles[channel].Add(DSPType.Gain, gainDspHandle);
+					
+					// Add low-high
+					_effects[channel].Add(EffectType.PeakEQ, lowEqHandle);
+					_effects[channel].Add(EffectType.PeakEQ + 1, midEqHandle);
+					_effects[channel].Add(EffectType.PeakEQ + 2, highEqHandle);
 				}
 			} else {
-				foreach (int channel in BassChannels) {
+				foreach (int channel in ReverbChannels) {
 					// No reverb is applied
 					if (!_effects[channel].ContainsKey(REVERB_TYPE)) {
 						return;
 					}
-
+					
+					// Remove low-high
+					Bass.ChannelRemoveFX(channel, _effects[channel][EffectType.PeakEQ]);
+					Bass.ChannelRemoveFX(channel, _effects[channel][EffectType.PeakEQ + 1]);
+					Bass.ChannelRemoveFX(channel, _effects[channel][EffectType.PeakEQ + 2]);
 					Bass.ChannelRemoveFX(channel, _effects[channel][REVERB_TYPE]);
-					Bass.ChannelRemoveDSP(channel, _dspHandles[channel][DSPType.Gain]);
+
+					Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, 0);
 
 					_effects[channel].Remove(REVERB_TYPE);
-					_dspHandles[channel].Remove(DSPType.Gain);
+					
+					// Remove low-high
+					_effects[channel].Remove(EffectType.PeakEQ);
+					_effects[channel].Remove(EffectType.PeakEQ + 1);
+					_effects[channel].Remove(EffectType.PeakEQ + 2);
 				}
 			}
 		}
@@ -158,7 +205,7 @@ namespace YARG {
 		}
 
 		public double GetLengthInSeconds() {
-			return GetChannelLengthInSeconds(_leadChannel);
+			return BassHelpers.GetChannelLengthInSeconds(_leadChannel);
 		}
 
 		public void Dispose() {
@@ -177,56 +224,22 @@ namespace YARG {
 				if (_isLoaded) {
 					for (var i = 0; i < BassChannels.Length; i++) {
 						if (!Bass.StreamFree(BassChannels[i])) {
-							Debug.LogError($"Failed to free MoggFX channel: {i} - {Bass.LastError}. THIS WILL LEAK MEMORY!");
+							Debug.LogError($"Failed to free Split MoggFX channel: {i} - {Bass.LastError}. THIS WILL LEAK MEMORY!");
 						}
 						
 						BassChannels[i] = 0;
+					}
+					for (var i = 0; i < ReverbChannels.Length; i++) {
+						if (!Bass.StreamFree(ReverbChannels[i])) {
+							Debug.LogError($"Failed to free Split Reverb MoggFX channel: {i} - {Bass.LastError}. THIS WILL LEAK MEMORY!");
+						}
+						
+						ReverbChannels[i] = 0;
 					}
 				}
 
 				_disposed = true;
 			}
-		}
-		
-		private static int AddReverbToChannel(int channel) {
-			// Set reverb FX
-			int reverbHandle = Bass.ChannelSetFX(channel, REVERB_TYPE, 0);
-			if (reverbHandle == 0) {
-				return 0;
-			}
-
-			IEffectParameter reverbParams = REVERB_TYPE switch {
-				EffectType.DXReverb => new DXReverbParameters {
-					fInGain = 0.0f, fReverbMix = -5f, fReverbTime = 1000.0f, fHighFreqRTRatio = 0.001f
-				},
-				EffectType.Freeverb => new ReverbParameters() {
-					fDryMix = 1f,
-					fWetMix = 2f,
-					fRoomSize = 0.5f,
-					fDamp = 0.2f,
-					fWidth = 1.0f,
-					lMode = 0
-				},
-				_ => throw new ArgumentOutOfRangeException()
-			};
-
-			return !Bass.FXSetParameters(reverbHandle, reverbParams) ? 0 : reverbHandle;
-		}
-		
-		private static double GetChannelLengthInSeconds(int channel) {
-			long length = Bass.ChannelGetLength(channel);
-
-			if (length == -1) {
-				return (double) Bass.LastError;
-			}
-
-			double seconds = Bass.ChannelBytes2Seconds(channel, length);
-
-			if (seconds < 0) {
-				return (double) Bass.LastError;
-			}
-
-			return seconds;
 		}
 	}	
 }

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using ManagedBass;
 using ManagedBass.DirectX8;
 using ManagedBass.Fx;
+using ManagedBass.Mix;
 
 namespace YARG {
 	public class BassStemChannel : IStemChannel {
@@ -15,6 +16,7 @@ namespace YARG {
 		public double Volume { get; private set; }
 
 		public int StreamHandle { get; private set; }
+		public int ReverbStreamHandle { get; private set; }
 
 		private readonly string _path;
 		private readonly IAudioManager _manager;
@@ -22,10 +24,17 @@ namespace YARG {
 		private readonly Dictionary<EffectType, int> _effects;
 		private readonly Dictionary<DSPType, int> _dspHandles;
 
-		private readonly DSPProcedure _dspGain;
+		private IEffectParameter _eqLowParams;
+		private IEffectParameter _eqMidParams;
+		private IEffectParameter _eqHighParams;
+		
+		//private readonly DSPProcedure _dspGain;
 
 		private double _lastStemVolume;
 
+		private int _sourceHandle;
+		
+		private bool _isReverbing;
 		private bool _disposed;
 
 		public BassStemChannel(IAudioManager manager, string path, SongStem stem) {
@@ -39,13 +48,14 @@ namespace YARG {
 			_effects = new Dictionary<EffectType, int>();
 			_dspHandles = new Dictionary<DSPType, int>();
 
-			_dspGain += GainDSP;
+			SetupEqParams();
+			
+			//_dspGain += GainDSP;
 		}
 
 		~BassStemChannel() {
 			Dispose(false);
 		}
-
 
 		public int Load(bool isSpeedUp, float speed) {
 			if (_disposed) {
@@ -55,27 +65,36 @@ namespace YARG {
 				return 0;
 			}
 
-			int streamHandle = Bass.CreateStream(_path, 0, 0, BassFlags.Prescan | BassFlags.Decode | BassFlags.AsyncFile);
-			if (streamHandle == 0) {
+			_sourceHandle = Bass.CreateStream(_path, 0, 0, BassFlags.Prescan | BassFlags.Decode | BassFlags.AsyncFile);
+			
+			if (_sourceHandle == 0) {
 				return (int) Bass.LastError;
 			}
+			
+			int main = BassMix.CreateSplitStream(_sourceHandle, BassFlags.Decode | BassFlags.SplitPosition, null);
+			int reverbSplit = BassMix.CreateSplitStream(_sourceHandle, BassFlags.Decode | BassFlags.SplitPosition, null);
 
 			const BassFlags flags = BassFlags.SampleOverrideLowestVolume | BassFlags.Decode | BassFlags.FxFreeSource;
-			StreamHandle = BassFx.TempoCreate(streamHandle, flags);
+			
+			StreamHandle = BassFx.TempoCreate(main, flags);
+			ReverbStreamHandle = BassFx.TempoCreate(reverbSplit, flags);
 
 			Bass.ChannelSetAttribute(StreamHandle, ChannelAttribute.Volume, _manager.GetVolumeSetting(Stem));
+			Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Volume, 0);
 
 			if (isSpeedUp) {
 				// Gets relative speed from 100% (so 1.05f = 5% increase)
 				float relativeSpeed = Math.Abs(speed) * 100;
 				relativeSpeed -= 100;
 				Bass.ChannelSetAttribute(StreamHandle, ChannelAttribute.Tempo, relativeSpeed);
+				Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Tempo, relativeSpeed);
 
 				// Have to handle pitch separately for some reason
 				if (_manager.IsChipmunkSpeedup) {
 					// Calculates semitone increase, can probably be improved but this will do for now
 					float semitones = relativeSpeed > 0 ? 1 * speed : -1 * speed;
 					Bass.ChannelSetAttribute(StreamHandle, ChannelAttribute.Pitch, semitones);
+					Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Pitch, semitones);
 				}
 			}
 
@@ -103,31 +122,60 @@ namespace YARG {
 			_lastStemVolume = volumeSetting;
 
 			Bass.ChannelSetAttribute(StreamHandle, ChannelAttribute.Volume, newBassVol);
+			
+			if (_isReverbing) {
+				Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Volume, newBassVol);
+			} else {
+				Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Volume, 0);
+			}
 		}
 
 		public void SetReverb(bool reverb) {
+			_isReverbing = reverb;
 			if (reverb) {
 				// Reverb already applied
 				if (_effects.ContainsKey(REVERB_TYPE))
 					return;
 
 				// Set reverb FX
-				int reverbHandle = AddReverbToChannel();
-				int gainDspHandle = Bass.ChannelSetDSP(StreamHandle, _dspGain);
+				int reverbFxHandle = AddReverbToChannel();
+				int lowEqHandle = AddEqToChannel(_eqLowParams);
+				int midEqHandle = AddEqToChannel(_eqMidParams);
+				int highEqHandle = AddEqToChannel(_eqHighParams);
+				//int gainDspHandle = Bass.ChannelSetDSP(StreamHandle, _dspGain);
+				
+				double volumeSetting = _manager.GetVolumeSetting(Stem);
+				Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Volume,volumeSetting * Volume);
 
-				_effects.Add(REVERB_TYPE, reverbHandle);
-				_dspHandles.Add(DSPType.Gain, gainDspHandle);
+				_effects.Add(REVERB_TYPE, reverbFxHandle);
+				
+				// Add low-high
+				_effects.Add(EffectType.PeakEQ, lowEqHandle);
+				_effects.Add(EffectType.PeakEQ + 1, midEqHandle);
+				_effects.Add(EffectType.PeakEQ + 2, highEqHandle);
+				//_dspHandles.Add(DSPType.Gain, gainDspHandle);
 			} else {
 				// No reverb is applied
 				if (!_effects.ContainsKey(REVERB_TYPE)) {
 					return;
 				}
 
-				Bass.ChannelRemoveFX(StreamHandle, _effects[REVERB_TYPE]);
-				Bass.ChannelRemoveDSP(StreamHandle, _dspHandles[DSPType.Gain]);
+				Bass.ChannelRemoveFX(ReverbStreamHandle, _effects[REVERB_TYPE]);
+				
+				// Remove low-high
+				Bass.ChannelRemoveFX(ReverbStreamHandle, _effects[EffectType.PeakEQ]);
+				Bass.ChannelRemoveFX(ReverbStreamHandle, _effects[EffectType.PeakEQ + 1]);
+				Bass.ChannelRemoveFX(ReverbStreamHandle, _effects[EffectType.PeakEQ + 2]);
+				//Bass.ChannelRemoveDSP(ReverbStreamHandle, _dspHandles[DSPType.Gain]);
+				Bass.ChannelSetAttribute(ReverbStreamHandle, ChannelAttribute.Volume, 0);
 
 				_effects.Remove(REVERB_TYPE);
-				_dspHandles.Remove(DSPType.Gain);
+				
+				// Remove low-high
+				_effects.Remove(EffectType.PeakEQ);
+				_effects.Remove(EffectType.PeakEQ + 1);
+				_effects.Remove(EffectType.PeakEQ + 2);
+				//_dspHandles.Remove(DSPType.Gain);
 			}
 		}
 
@@ -173,20 +221,30 @@ namespace YARG {
 					StreamHandle = 0;
 				}
 
+				if (ReverbStreamHandle != 0) {
+					Bass.StreamFree(ReverbStreamHandle);
+					ReverbStreamHandle = 0;
+				}
+
+				if (_sourceHandle != 0) {
+					Bass.StreamFree(_sourceHandle);
+					_sourceHandle = 0;
+				}
+
 				_disposed = true;
 			}
 		}
 
 		private int AddReverbToChannel() {
 			// Set reverb FX
-			int reverbHandle = Bass.ChannelSetFX(StreamHandle, REVERB_TYPE, 0);
-			if (reverbHandle == 0) {
+			int reverbFxHandle = Bass.ChannelSetFX(ReverbStreamHandle, REVERB_TYPE, 0);
+			if (reverbFxHandle == 0) {
 				return 0;
 			}
 
 			IEffectParameter reverbParams = REVERB_TYPE switch {
 				EffectType.DXReverb => new DXReverbParameters {
-					fInGain = 0.0f, fReverbMix = -5f, fReverbTime = 1000.0f, fHighFreqRTRatio = 0.001f
+					fInGain = -2f, fReverbMix = -1f, fReverbTime = 1000.0f, fHighFreqRTRatio = 0.001f
 				},
 				EffectType.Freeverb => new ReverbParameters() {
 					fDryMix = 1f,
@@ -199,9 +257,38 @@ namespace YARG {
 				_ => throw new ArgumentOutOfRangeException()
 			};
 
-			return !Bass.FXSetParameters(reverbHandle, reverbParams) ? 0 : reverbHandle;
+			return !Bass.FXSetParameters(reverbFxHandle, reverbParams) ? 0 : reverbFxHandle;
 		}
 
+		private int AddEqToChannel(IEffectParameter eqParams) {
+			int eqHandle = Bass.ChannelSetFX(ReverbStreamHandle, EffectType.PeakEQ, 1);
+			if (eqHandle == 0) {
+				return 0;
+			}
+			
+			return !Bass.FXSetParameters(eqHandle, eqParams) ? 0 : eqHandle;
+		}
+
+		private void SetupEqParams() {
+			_eqLowParams = new PeakEQParameters {
+				fBandwidth = 2.0f,
+				fCenter = 500.0f,
+				fGain = -20f
+			};
+			
+			_eqMidParams = new PeakEQParameters {
+				fBandwidth = 2.0f,
+				fCenter = 1500.0f,
+				fGain = -5f
+			};
+			
+			_eqHighParams = new PeakEQParameters {
+				fBandwidth = 3.0f,
+				fCenter = 5000.0f,
+				fGain = 4f
+			};
+		}
+		
 		public static unsafe void GainDSP(int handle, int channel, IntPtr buffer, int length, IntPtr user) {
 			var bufferPtr = (float*) buffer;
 			int samples = length / 4;

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -149,6 +149,10 @@ namespace YARG {
 			if (!BassMix.MixerAddChannel(_mixerHandle, bassChannel.StreamHandle, BassFlags.Default)) {
 				return (int) Bass.LastError;
 			}
+			
+			if (!BassMix.MixerAddChannel(_mixerHandle, bassChannel.ReverbStreamHandle, BassFlags.Default)) {
+				return (int) Bass.LastError;
+			}
 
 			_channels.Add(channel.Stem, channel);
 			StemsLoaded++;

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -175,8 +175,13 @@ namespace YARG {
 
 			for (var i = 0; i < moggStem.BassChannels.Length; i++) {
 				int bassChannel = moggStem.BassChannels[i];
+				int reverbChannel = moggStem.ReverbChannels[i];
 
 				if (!BassMix.MixerAddChannel(_mixerHandle, bassChannel, BassFlags.MixerChanMatrix)) {
+					return (int) Bass.LastError;
+				}
+				
+				if (!BassMix.MixerAddChannel(_mixerHandle, reverbChannel, BassFlags.MixerChanMatrix)) {
 					return (int) Bass.LastError;
 				}
 
@@ -186,6 +191,10 @@ namespace YARG {
 				};
 
 				if (!BassMix.ChannelSetMatrix(bassChannel, channelPanVol)) {
+					return (int) Bass.LastError;
+				}
+				
+				if (!BassMix.ChannelSetMatrix(reverbChannel, channelPanVol)) {
 					return (int) Bass.LastError;
 				}
 			}

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -25,7 +25,7 @@ namespace YARG {
 
 		public void LoadSfx();
 
-		public void LoadSong(IEnumerable<string> stems, bool isSpeedUp);
+		public void LoadSong(ICollection<string> stems, bool isSpeedUp);
 		public void LoadMogg(XboxMoggData moggData, bool isSpeedUp);
 		public void UnloadSong();
 

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -174,8 +174,6 @@ namespace YARG.PlayMode {
 					Play.Instance.ReverbAudio("keys", on);
 					break;
 			}
-
-			Play.Instance.ReverbAudio("song", on);
 		}
 
 		private void UpdateInput() {

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -43,6 +43,8 @@ namespace YARG.PlayMode {
 		private OccurrenceList<string> audioLowering = new();
 		private OccurrenceList<string> audioReverb = new();
 
+		private int stemsReverbed;
+		
 		private float realSongTime;
 		public float SongTime {
 			get => realSongTime + PlayerManager.GlobalCalibration * speed;
@@ -350,6 +352,8 @@ namespace YARG.PlayMode {
 			// Reverb audio with starpower
 
 			if (GameManager.AudioManager.UseStarpowerFx) {
+				GameManager.AudioManager.ApplyReverb(SongStem.Song, stemsReverbed > 0);
+				
 				foreach (var name in stemNames) {
 					var stem = AudioHelpers.GetStemFromName(name);
 
@@ -397,8 +401,10 @@ namespace YARG.PlayMode {
 
 		public void ReverbAudio(string name, bool apply) {
 			if (apply) {
+				stemsReverbed++;
 				audioReverb.Add(name);
 			} else {
+				stemsReverbed--;
 				audioReverb.Remove(name);
 			}
 		}


### PR DESCRIPTION
Got a couple complaints that the reverb on star power is extremely bad on single stem songs, that's because it previously reverbed the whole channel and also applied gain. I've made some changes to that:
- Split stems into 2 channels, original channel and reverb channel.
- Apply an EQ to wipe out the bass frequencies and lower the lower mid frequencies of the reverb channel.
- Boost the higher mid/treble frequencies in the reverb channel slightly.
- Reverb the new channel with majority wet mix and very little dry mix.
- Play the reverb channel at 70% volume of the regular channel when star power is active.
- Mute the reverb channel when star power is inactive.

These changes prevent bass frequencies from being reverbed and sounding really bad. It also makes the audio sound brighter without actually making it much louder.

I also made a few other QoL improvements to the audio:
- Single stem songs are no longer muted when missing, and the stem is assigned to the Song stem always.
- Apply a compressor effect to each stem (and its reverb channel). This will prevent peaking and fixes horrible audio such as Jordan's bass stem.
- Split a few things up that were the same between regular stem and Mogg stems and put them into a helper class.
- Increased the volume of some sound effects very slightly.