### PR TITLE
Note count fix, solo reset fix*, slightly easier tap recovery

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -55,7 +55,7 @@ namespace YARG.PlayMode {
 
 		// Solo stuff
 		private bool soloInProgress = false;
-		private int soloNoteCount = -1;
+		protected int soloNoteCount = -1;
 		protected int soloNotesHit = 0;
 		private float soloHitPercent = 0;
 		private int lastHit = -1;
@@ -176,7 +176,7 @@ namespace YARG.PlayMode {
 			player.lastScore = new PlayerManager.LastScore {
 				percentage = new DiffPercent {
 					difficulty = player.chosenDifficulty,
-					percent = Chart.Count == 0 ? 1f : (float) notesHit / Chart.Count
+					percent = Chart.Count == 0 ? 1f : (float) notesHit / GetChartCount()
 				},
 				score = new DiffScore {
 					difficulty = player.chosenDifficulty,
@@ -184,7 +184,7 @@ namespace YARG.PlayMode {
 					stars = math.clamp((int) starsKeeper.Stars, 0, 6)
 				},
 				notesHit = notesHit,
-				notesMissed = Chart.Count - notesHit
+				notesMissed = GetChartCount() - notesHit
 			};
 
 			Play.OnPauseToggle -= PauseToggled;
@@ -370,6 +370,7 @@ namespace YARG.PlayMode {
 			if (Play.Instance.SongTime >= SoloSection?.time - 2 && Play.Instance.SongTime <= SoloSection?.time) {
 				// run ONCE
 				if (!soloInProgress) {
+					soloNotesHit = 0; // Reset count
 					soloInProgress = true;
 				}
 
@@ -379,7 +380,7 @@ namespace YARG.PlayMode {
 					if (Chart[i].time > SoloSection?.EndTime) {
 						break;
 					} else {
-						soloNoteCount++;
+						AddSoloNoteCount(i);
 					}
 				}
 			}
@@ -408,6 +409,7 @@ namespace YARG.PlayMode {
 				// run ONCE
 				if (soloInProgress) {
 					soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
+					soloNotesHit = 0; // Reset count
 
 					// set box text
 					if (soloHitPercent >= 100f) {
@@ -496,5 +498,12 @@ namespace YARG.PlayMode {
 		}
 
 		public abstract void SetReverb(bool on);
+
+		public virtual void AddSoloNoteCount(int i) {
+			soloNoteCount++;
+		}
+		public virtual int GetChartCount() {
+			return Chart.Count;
+		}
 	}
 }

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -295,7 +295,7 @@ namespace YARG.PlayMode {
 			}
 			// If tapping to recover combo during tap note section, skip to first valid note within the timing window.
 			// This will make it easier to recover.
-			if (Constants.EASY_TAP_RECOVERY && Combo <= 0 && pressedThisFrame && chord[0].tap && !ChordPressed(chord)) {
+			if (Constants.EASY_TAP_RECOVERY && Combo <= 0 /*&& pressedThisFrame*/ && chord[0].tap && !ChordPressed(chord)) {
 				var found = false;
 				foreach (var newChord in expectedHits) {
 					if (!newChord[0].tap) {
@@ -354,9 +354,16 @@ namespace YARG.PlayMode {
 
 			ResetAllowedChordGhosts();
 			Combo++;
+			notesHit++;
 			strummedCurrentNote = strummedCurrentNote || strummed || strumLeniency > 0f;
 			strumLeniency = 0f;
 			StopAudio = false;
+
+
+			// Solo stuff
+			if (Play.Instance.SongTime >= SoloSection?.time && Play.Instance.SongTime <= SoloSection?.EndTime) {
+				soloNotesHit++;
+			}
 			foreach (var hit in chord) {
 				hitChartIndex++;
 				// Hit notes
@@ -388,15 +395,7 @@ namespace YARG.PlayMode {
 				}
 
 				// Add stats
-				notesHit++;
 				scoreKeeper.Add(PTS_PER_NOTE * Multiplier);
-
-				// Solo stuff
-				if (Play.Instance.SongTime >= SoloSection?.time && Play.Instance.SongTime <= SoloSection?.EndTime) {
-					soloNotesHit++;
-				} else if (Play.Instance.SongTime >= SoloSection?.EndTime + 10) {
-					soloNotesHit = 0;
-				}
 			}
 
 			// If this is a tap note, and it was hit without strumming,
@@ -779,6 +778,21 @@ namespace YARG.PlayMode {
 
 		private bool IsExtendedSustain() {
 			return extendedSustain.Any(x => x);
+		}
+
+		public override void AddSoloNoteCount(int i) {
+			if (i == 0 || Chart[i].time > Chart[i-1].time) {
+				soloNoteCount++;
+			}
+		}
+		public override int GetChartCount() {
+			int count = 0;
+			for (int i = 0; i < Chart.Count; i++) {
+				if (i == 0 || Chart[i].time > Chart[i-1].time) {
+					count++;
+				}
+			}
+			return count;
 		}
 	}
 }


### PR DESCRIPTION
Maybe I shouldn't do multiple things in a single commit lol
- Note count fix
  - Chords were treated as separate notes when counting, so the total note count, the notes hit count (and as a result, the note missed count) were inaccurate (i.e. Soulless 3 has 4066 notes instead of 3999);
  - Solo note count, albeit done separately, suffered from the same issue, which was also fixed.
- Solo reset fix*
  - Solo is now reset in the part of the code that starts it/shows its results;
  - **ADJACENT SOLOS ARE STILL BROKEN!** Solo region start/end will need to be reworked for this to be solved, which is not the goal of this PR.
- Slightly easier tap recovery
  - Removed `pressedThisFrame` check in FiveFretTrack.cs line 298 to allow tap recovery by doing pull-offs rather than just button presses.