### PR TITLE
Fix bonus solo points being awarded when solo completion is MESSY (50-59%)

### DIFF
--- a/Assets/Script/PlayMode/ScoreKeeper.cs
+++ b/Assets/Script/PlayMode/ScoreKeeper.cs
@@ -46,11 +46,11 @@ namespace YARG.PlayMode {
 		public double AddSolo(int notesHit, int notesMax) {
 			double ratio = (double) notesHit / notesMax;
 
-			if (ratio <= 0.5)
+			if (ratio < 0.6)
 				return 0;
 
 			// linear
-			double multiplier = math.clamp((ratio - 0.5) / 0.5, 0, 1);
+			double multiplier = math.clamp((ratio - 0.6) / 0.4, 0, 1);
 			double ptsEarned = 100 * notesHit * multiplier;
 
 			// +5% bonus points


### PR DESCRIPTION
Adjusted solo bonus scoring minimum to be at 60% instead of 50%.

Addresses #227 