### PR TITLE
minor overstrum-related fix

### DIFF
--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -400,7 +400,7 @@ namespace YARG.PlayMode {
 			// doesn't lose their combo when they strum AFTER they hit
 			// the tap note.
 			if ((chord[0].hopo || chord[0].tap) && !strummedCurrentNote) {
-				allowedOverstrums.Clear(); // Only allow overstrumming latest HO/PO
+				//allowedOverstrums.Clear();
 				allowedOverstrums.Add(chord);
 			} else if (allowedOverstrums.Count > 0 && !chord[0].hopo && !chord[0].tap) {
 				for (int i = 0; i < allowedOverstrums.Count; i++) {


### PR DESCRIPTION
That line would cause issues in sequences with lots of taps of the same fret (i.e. Charmeleon Carneval (Andromeda Solo Medley chart)) while not fixing any real problems