### PR TITLE
(maybe) fix issue with dta files containing brackets in symbols

### DIFF
--- a/Assets/Script/DtxCs/DTX.cs
+++ b/Assets/Script/DtxCs/DTX.cs
@@ -304,17 +304,6 @@ namespace DtxCS
               case '\n':
               case '\t':
                 throw new Exception("Whitespace encountered in symbol.");
-              case '}':
-              case ')':
-              case ']':
-                current.AddNode(DataSymbol.Symbol(tmp_literal));
-                if (data[i] != current.ClosingChar)
-                {
-                  throw new Exception("Mismatched brace types encountered.");
-                }
-                current = current.Parent;
-                state = ParseState.whitespace;
-                break;
               case '\'':
                 current.AddNode(DataSymbol.Symbol(tmp_literal));
                 state = ParseState.whitespace;


### PR DESCRIPTION
The DtxCS DTA parser included a check for ending brackets in the middle of symbol parsing, breaking parsing of certain songs that included brackets in their shortnames.

I can't immediately tell any reason for this being here as it breaks the flow of the parser when the case is hit (the next `'` that is hit at the end of the symbol causes a new symbol to begin, causing the "whitespace encountered in symbol error"), but it *could* break other songs. Might be worth testing on a large library before merging.